### PR TITLE
Guardian Stability Track (v0.11.3): OSV cache resilience, retries, concurrency gate, and versioned keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.3] - 2025-12-17 "Guardian Stability Track"
+
+**Guardian Next stability track completed**: This release solidifies the OSV integration with a focus on reliability, concurrency control, and crash safety.
+
+### 🛡️ Guardian: Robustness & Resilience
+- **Concurrency Control**: Implemented `ConcurrencyGate` (`max_in_flight: 8`) and budget-aware permits to prevent OSV API overload.
+- **Atomic Writes**: Cache files are now written atomically (tmp + sync + rename) to guarantee no partial JSON corruption on crashes.
+- **File Locking**: Added multi-process file locking (`fs2`) to safely handle parallel scans (e.g., CI jobs) sharing the same cache.
+- **Key Versioning**: Migrated cache storage to a `v1/` directory with strict filename normalization and collision avoidance, preserving legacy read compatibility.
+- **Retry Policy**: Enhanced retry logic with jittered backoff and strict `Retry-After` header respect.
+
 ## [0.11.2] - 2025-12-16
 
 ### 🛡️ Guardian: Performance Improvements (OSV)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,6 +898,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,7 +3582,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veil-cli"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3604,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "veil-config"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "regex",
@@ -3615,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "veil-core"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3633,11 +3643,13 @@ dependencies = [
 
 [[package]]
 name = "veil-guardian"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
+ "async-trait",
  "blake3",
  "cargo-lock",
  "directories",
+ "fs2",
  "futures",
  "hex",
  "insta",
@@ -3655,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "veil-server"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,15 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.2"
+version = "0.11.3"
 rust-version = "1.82.0"
 edition = "2021"
 
 [workspace.dependencies]
-veil-core = { path = "crates/veil-core", version = "0.11.2" }
-veil-guardian = { path = "crates/veil-guardian", version = "0.11.2" }
-veil-config = { path = "crates/veil-config", version = "0.11.2" }
-veil-server = { path = "crates/veil-server", version = "0.11.2" }
+veil-core = { path = "crates/veil-core", version = "0.11.3" }
+veil-guardian = { path = "crates/veil-guardian", version = "0.11.3" }
+veil-config = { path = "crates/veil-config", version = "0.11.3" }
+veil-server = { path = "crates/veil-server", version = "0.11.3" }
 
 [profile.bench]
 opt-level = 3

--- a/crates/veil-cli/Cargo.toml
+++ b/crates/veil-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veil-cli"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version.workspace = true
 

--- a/crates/veil-config/Cargo.toml
+++ b/crates/veil-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veil-config"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version.workspace = true
 

--- a/crates/veil-core/Cargo.toml
+++ b/crates/veil-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veil-core"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version.workspace = true
 

--- a/crates/veil-guardian/Cargo.toml
+++ b/crates/veil-guardian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veil-guardian"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version.workspace = true
 description = "Security advisory and policy enforcement module for Veil"
@@ -18,8 +18,10 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 directories = "5.0"
 blake3 = "1.5"
 hex = "0.4"
-tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "sync"] }
+tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
 futures = "0.3.31"
+async-trait = "0.1"
+fs2 = "0.4.3"
 
 [dev-dependencies]
 wiremock = "=0.6.4"

--- a/crates/veil-guardian/src/guardian_next/cache/disk.rs
+++ b/crates/veil-guardian/src/guardian_next/cache/disk.rs
@@ -1,0 +1,71 @@
+use super::CacheStore;
+use crate::guardian_next::types::{CacheEntry, CacheKey};
+use serde::{de::DeserializeOwned, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Clone)]
+pub struct DiskCache {
+    dir: PathBuf,
+}
+
+impl DiskCache {
+    pub fn new(dir: PathBuf) -> std::io::Result<Self> {
+        fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+
+    pub fn default_dir(app_name: &str) -> PathBuf {
+        // XDG_CACHE_HOME > ~/.cache
+        let base = std::env::var_os("XDG_CACHE_HOME")
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+            .unwrap_or_else(|| PathBuf::from(".cache"));
+
+        base.join(app_name).join("guardian_next")
+    }
+
+    fn key_path(&self, key: &CacheKey) -> PathBuf {
+        // 安全にファイル名化（超単純版）: ':' -> '_'
+        let safe = key.0.replace(':', "_");
+        self.dir.join(format!("{safe}.json"))
+    }
+}
+
+impl<T> CacheStore<T> for DiskCache
+where
+    T: Serialize + DeserializeOwned + Send + Sync,
+{
+    fn get(&self, key: &CacheKey) -> std::io::Result<Option<CacheEntry<T>>> {
+        let path = self.key_path(key);
+        crate::util::file_lock::with_file_lock(&path, || {
+            if !path.exists() {
+                return Ok(None);
+            }
+            let bytes = fs::read(&path)?;
+            let entry: CacheEntry<T> = serde_json::from_slice(&bytes)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            Ok(Some(entry))
+        })
+    }
+
+    fn put(&self, entry: &CacheEntry<T>) -> std::io::Result<()> {
+        let key = CacheKey(entry.meta.key.clone());
+        let path = self.key_path(&key);
+        let bytes = serde_json::to_vec_pretty(entry)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        crate::util::file_lock::with_file_lock(&path, || {
+            crate::util::atomic_write::atomic_write_bytes(&path, &bytes)
+        })?;
+        Ok(())
+    }
+
+    fn touch(&self, key: &CacheKey, now_unix: u64) -> std::io::Result<()> {
+        if let Some(mut entry) = <DiskCache as CacheStore<T>>::get(self, key)? {
+            entry.meta.fetched_at_unix = now_unix;
+            self.put(&entry)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/veil-guardian/src/guardian_next/cache/memory.rs
+++ b/crates/veil-guardian/src/guardian_next/cache/memory.rs
@@ -1,0 +1,44 @@
+use super::CacheStore;
+use crate::guardian_next::types::{CacheEntry, CacheKey};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+#[derive(Clone)]
+pub struct MemoryCache<T> {
+    inner: Arc<RwLock<HashMap<CacheKey, CacheEntry<T>>>>,
+}
+
+impl<T> MemoryCache<T> {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+impl<T> Default for MemoryCache<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Clone + Send + Sync> CacheStore<T> for MemoryCache<T> {
+    fn get(&self, key: &CacheKey) -> std::io::Result<Option<CacheEntry<T>>> {
+        Ok(self.inner.read().unwrap().get(key).cloned())
+    }
+
+    fn put(&self, entry: &CacheEntry<T>) -> std::io::Result<()> {
+        self.inner
+            .write()
+            .unwrap()
+            .insert(CacheKey(entry.meta.key.clone()), entry.clone());
+        Ok(())
+    }
+
+    fn touch(&self, key: &CacheKey, now_unix: u64) -> std::io::Result<()> {
+        if let Some(e) = self.inner.write().unwrap().get_mut(key) {
+            e.meta.fetched_at_unix = now_unix;
+        }
+        Ok(())
+    }
+}

--- a/crates/veil-guardian/src/guardian_next/cache/mod.rs
+++ b/crates/veil-guardian/src/guardian_next/cache/mod.rs
@@ -1,0 +1,17 @@
+use crate::guardian_next::types::{CacheEntry, CacheKey};
+use std::time::SystemTime;
+
+pub mod disk;
+pub mod memory;
+
+pub trait CacheStore<T>: Send + Sync {
+    fn get(&self, key: &CacheKey) -> std::io::Result<Option<CacheEntry<T>>>;
+    fn put(&self, entry: &CacheEntry<T>) -> std::io::Result<()>;
+    fn touch(&self, key: &CacheKey, now_unix: u64) -> std::io::Result<()>;
+
+    fn now_unix(now: SystemTime) -> u64 {
+        now.duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+}

--- a/crates/veil-guardian/src/guardian_next/error.rs
+++ b/crates/veil-guardian/src/guardian_next/error.rs
@@ -1,0 +1,37 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GuardianNextError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("HTTP status error: {status} {body}")]
+    HttpStatus { status: u16, body: String },
+
+    #[error("Network error: {0}")]
+    Network(String),
+
+    #[error("offline and no usable cache: {0}")]
+    NoUsableCache(String),
+
+    #[error("timeout budget exceeded")]
+    TimeoutBudget,
+
+    #[error("internal: {0}")]
+    Internal(String),
+}
+
+impl GuardianNextError {
+    pub fn http_status(status: reqwest::StatusCode, body: String) -> Self {
+        Self::HttpStatus {
+            status: status.as_u16(),
+            body,
+        }
+    }
+}

--- a/crates/veil-guardian/src/guardian_next/fetcher.rs
+++ b/crates/veil-guardian/src/guardian_next/fetcher.rs
@@ -1,0 +1,250 @@
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use crate::guardian_next::cache::disk::DiskCache;
+use crate::guardian_next::cache::CacheStore;
+use crate::guardian_next::error::GuardianNextError;
+use crate::guardian_next::net::concurrency::{ConcurrencyGate, ConcurrencyPolicy};
+use crate::guardian_next::net::http_client::{FetchJsonResult, HttpClient, ReqwestHttpClient};
+use crate::guardian_next::net::retry::RetryRunner;
+use crate::guardian_next::net::SingleFlight;
+use crate::guardian_next::outcome::FetchOutcome;
+use crate::guardian_next::types::{CacheEntry, CacheFreshness, CacheKey, CacheMeta};
+
+#[derive(Clone)]
+pub struct GuardianNextConfig {
+    pub offline: bool,
+    pub ttl: Duration,
+    pub grace: Duration,
+    pub http_timeout_ms: u64,
+    pub retry: crate::guardian_next::net::retry::RetryPolicy,
+    pub concurrency: usize,
+    pub cache_dir: std::path::PathBuf,
+}
+
+impl Default for GuardianNextConfig {
+    fn default() -> Self {
+        Self {
+            offline: false,
+            ttl: Duration::from_secs(24 * 60 * 60),
+            grace: Duration::from_secs(7 * 24 * 60 * 60),
+            http_timeout_ms: 10000,
+            retry: crate::guardian_next::net::retry::RetryPolicy::default(),
+            concurrency: 10,
+            cache_dir: std::env::temp_dir().join("veil_guardian_next"),
+        }
+    }
+}
+
+pub struct GuardianNext {
+    config: GuardianNextConfig,
+    cache: DiskCache,
+    http: Arc<ReqwestHttpClient>,
+    retry: RetryRunner,
+    concurrency: ConcurrencyGate,
+    single_flight:
+        SingleFlight<CacheKey, Result<(serde_json::Value, FetchOutcome), Arc<GuardianNextError>>>,
+}
+
+impl GuardianNext {
+    pub fn new(
+        config: GuardianNextConfig,
+        http: Arc<ReqwestHttpClient>,
+    ) -> Result<Self, GuardianNextError> {
+        let cache = DiskCache::new(config.cache_dir.clone()).map_err(GuardianNextError::Io)?;
+        let retry = RetryRunner::new(config.retry.clone());
+        let concurrency = ConcurrencyGate::new(ConcurrencyPolicy {
+            max_in_flight: config.concurrency,
+        });
+
+        Ok(Self {
+            config,
+            cache,
+            http,
+            retry,
+            concurrency,
+            single_flight: SingleFlight::new(),
+        })
+    }
+
+    pub async fn get_osv_details_json(
+        &self,
+        id: &str,
+    ) -> Result<(serde_json::Value, FetchOutcome), Arc<GuardianNextError>> {
+        let url = format!("https://api.osv.dev/v1/vulns/{}", id);
+        let key = CacheKey(format!("osv:vuln:{}", id));
+        self.get_json_with_policy(&key, &url).await
+    }
+
+    pub async fn get_json_with_policy(
+        &self,
+        key: &CacheKey,
+        url: &str,
+    ) -> Result<(serde_json::Value, FetchOutcome), Arc<GuardianNextError>> {
+        let http = self.http.clone();
+        let cache = self.cache.clone();
+        let retry = self.retry.clone();
+        let gate = self.concurrency.clone();
+
+        let key_owned = key.clone();
+        let url_owned = url.to_string();
+        let offline = self.config.offline;
+        let ttl = self.config.ttl;
+        let grace = self.config.grace;
+        let timeout_ms = self.config.http_timeout_ms;
+
+        self.single_flight
+            .do_call(key.clone(), move || async move {
+                execute_fetch_logic(
+                    key_owned, url_owned, http, cache, retry, gate, offline, ttl, grace, timeout_ms,
+                )
+                .await
+                .map_err(Arc::new)
+            })
+            .await
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_fetch_logic(
+    key: CacheKey,
+    url: String,
+    http: Arc<ReqwestHttpClient>,
+    cache: DiskCache,
+    retry: RetryRunner,
+    gate: ConcurrencyGate,
+    offline: bool,
+    ttl: Duration,
+    grace: Duration,
+    timeout_ms: u64,
+) -> Result<(serde_json::Value, FetchOutcome), GuardianNextError> {
+    let now = SystemTime::now();
+    let now_unix = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+
+    // 1. Check Cache
+    // Implicitly defines T = serde_json::Value via assignment
+    let cache_val: Option<CacheEntry<serde_json::Value>> =
+        cache.get(&key).map_err(GuardianNextError::Io)?; // Explicit check? get returns Result
+
+    // Actually cache.get returns std::io::Result.
+    // If we use helper var, types are inferred.
+
+    if let Some(entry) = cache_val {
+        let freshness = entry.freshness(now, grace);
+
+        match freshness {
+            CacheFreshness::Fresh => {
+                let outcome = if offline {
+                    FetchOutcome::OfflineUsedFreshCache
+                } else {
+                    FetchOutcome::CacheHitFresh
+                };
+                return Ok((entry.payload, outcome));
+            }
+            CacheFreshness::StaleUsable => {
+                if offline {
+                    return Ok((entry.payload, FetchOutcome::OfflineFallbackUsedStale));
+                }
+            }
+            CacheFreshness::Expired => {
+                if offline {
+                    return Err(GuardianNextError::NoUsableCache(
+                        "Offline and cache expired".into(),
+                    ));
+                }
+            }
+        }
+
+        let etag = entry.meta.etag.clone();
+
+        // Refresh with Concurrency Rate Limit
+        let result = retry
+            .run(|_| {
+                let u = url.clone();
+                let h = http.clone();
+                let et = etag.clone();
+                let g = gate.clone();
+                async move {
+                    let _permit = g.acquire().await;
+                    h.fetch_json::<serde_json::Value>(&u, et.as_deref(), timeout_ms)
+                        .await
+                }
+            })
+            .await;
+
+        match result {
+            Ok(FetchJsonResult::Fetched {
+                payload: val,
+                etag: new_etag,
+            }) => {
+                let meta = CacheMeta::new(key.clone(), now, ttl.as_secs(), new_etag);
+                let new_entry = CacheEntry {
+                    meta,
+                    payload: val.clone(),
+                };
+                cache.put(&new_entry)?;
+                Ok((val, FetchOutcome::NetworkFetched))
+            }
+            Ok(FetchJsonResult::NotModified) => {
+                // Explicitly specify T=Value for touch
+                CacheStore::<serde_json::Value>::touch(&cache, &key, now_unix)?;
+
+                // Re-read payload
+                if let Some(e) = CacheStore::<serde_json::Value>::get(&cache, &key)? {
+                    Ok((e.payload, FetchOutcome::NetworkNotModified))
+                } else {
+                    // Should not happen as we just touched
+                    Ok((entry.payload, FetchOutcome::NetworkNotModified))
+                }
+            }
+            Err(e) => {
+                if let CacheFreshness::StaleUsable = freshness {
+                    Ok((entry.payload, FetchOutcome::CacheHitStaleFallback))
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    } else {
+        if offline {
+            return Err(GuardianNextError::NoUsableCache(
+                "Offline and no cache".into(),
+            ));
+        }
+
+        let result = retry
+            .run(|_| {
+                let u = url.clone();
+                let h = http.clone();
+                let g = gate.clone();
+                async move {
+                    let _permit = g.acquire().await;
+                    h.fetch_json::<serde_json::Value>(&u, None, timeout_ms)
+                        .await
+                }
+            })
+            .await;
+
+        match result {
+            Ok(FetchJsonResult::Fetched {
+                payload: val,
+                etag: new_etag,
+            }) => {
+                let meta = CacheMeta::new(key.clone(), now, ttl.as_secs(), new_etag);
+                let new_entry = CacheEntry {
+                    meta,
+                    payload: val.clone(),
+                };
+                cache.put(&new_entry)?;
+                Ok((val, FetchOutcome::NetworkFetched))
+            }
+            Ok(FetchJsonResult::NotModified) => Err(GuardianNextError::Network(
+                "Unexpected 304 without cache".into(),
+            )),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/crates/veil-guardian/src/guardian_next/mod.rs
+++ b/crates/veil-guardian/src/guardian_next/mod.rs
@@ -1,0 +1,11 @@
+pub mod cache;
+pub mod error;
+pub mod fetcher;
+pub mod net;
+pub mod outcome;
+pub mod types;
+
+pub use error::GuardianNextError;
+pub use fetcher::{GuardianNext, GuardianNextConfig};
+pub use outcome::{FetchOutcome, OutcomeLabel};
+pub use types::{CacheEntry, CacheFreshness, CacheKey};

--- a/crates/veil-guardian/src/guardian_next/net/concurrency.rs
+++ b/crates/veil-guardian/src/guardian_next/net/concurrency.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+#[derive(Debug, Clone)]
+pub struct ConcurrencyPolicy {
+    pub max_in_flight: usize,
+}
+
+#[derive(Clone)]
+pub struct ConcurrencyGate {
+    sem: Arc<Semaphore>,
+}
+
+impl ConcurrencyGate {
+    pub fn new(policy: ConcurrencyPolicy) -> Self {
+        let n = policy.max_in_flight.max(1);
+        Self {
+            sem: Arc::new(Semaphore::new(n)),
+        }
+    }
+
+    pub async fn acquire(&self) -> tokio::sync::OwnedSemaphorePermit {
+        self.sem
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("semaphore closed")
+    }
+}

--- a/crates/veil-guardian/src/guardian_next/net/http_client.rs
+++ b/crates/veil-guardian/src/guardian_next/net/http_client.rs
@@ -1,0 +1,68 @@
+use crate::guardian_next::error::GuardianNextError;
+use reqwest::header::{ETAG, IF_NONE_MATCH};
+
+#[derive(Debug)]
+pub enum FetchJsonResult<T> {
+    Fetched { payload: T, etag: Option<String> },
+    NotModified,
+}
+
+#[async_trait::async_trait]
+pub trait HttpClient: Send + Sync {
+    async fn fetch_json<T: serde::de::DeserializeOwned + Send>(
+        &self,
+        url: &str,
+        etag: Option<&str>,
+        timeout_ms: u64,
+    ) -> Result<FetchJsonResult<T>, GuardianNextError>;
+}
+
+pub struct ReqwestHttpClient {
+    client: reqwest::Client,
+}
+
+impl ReqwestHttpClient {
+    pub fn new() -> Result<Self, GuardianNextError> {
+        let client = reqwest::Client::builder()
+            .user_agent("veil-guardian-next")
+            .build()?;
+        Ok(Self { client })
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpClient for ReqwestHttpClient {
+    async fn fetch_json<T: serde::de::DeserializeOwned + Send>(
+        &self,
+        url: &str,
+        etag: Option<&str>,
+        timeout_ms: u64,
+    ) -> Result<FetchJsonResult<T>, GuardianNextError> {
+        let mut req = self
+            .client
+            .get(url)
+            .timeout(std::time::Duration::from_millis(timeout_ms));
+        if let Some(et) = etag {
+            req = req.header(IF_NONE_MATCH, et);
+        }
+
+        let resp = req.send().await?;
+        if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+            return Ok(FetchJsonResult::NotModified);
+        }
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(GuardianNextError::http_status(status, body));
+        }
+
+        let etag = resp
+            .headers()
+            .get(ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let payload = resp.json::<T>().await?;
+        Ok(FetchJsonResult::Fetched { payload, etag })
+    }
+}

--- a/crates/veil-guardian/src/guardian_next/net/mod.rs
+++ b/crates/veil-guardian/src/guardian_next/net/mod.rs
@@ -1,0 +1,9 @@
+pub mod concurrency;
+pub mod http_client;
+pub mod retry;
+pub mod singleflight;
+
+pub use concurrency::{ConcurrencyGate, ConcurrencyPolicy};
+pub use http_client::{FetchJsonResult, HttpClient, ReqwestHttpClient};
+pub use retry::{RetryPolicy, RetryRunner};
+pub use singleflight::SingleFlight;

--- a/crates/veil-guardian/src/guardian_next/net/retry.rs
+++ b/crates/veil-guardian/src/guardian_next/net/retry.rs
@@ -1,0 +1,79 @@
+use crate::guardian_next::error::GuardianNextError;
+use std::time::Duration;
+use tokio::time::sleep;
+
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    pub max_attempts: usize,  // 例: 4
+    pub base_delay: Duration, // 例: 200ms
+    pub max_delay: Duration,  // 例: 3s
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 4,
+            base_delay: Duration::from_millis(200),
+            max_delay: Duration::from_secs(3),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RetryRunner {
+    policy: RetryPolicy,
+}
+
+impl RetryRunner {
+    pub fn new(policy: RetryPolicy) -> Self {
+        Self { policy }
+    }
+
+    pub fn should_retry(err: &GuardianNextError) -> bool {
+        match err {
+            GuardianNextError::HttpStatus { status, .. } => {
+                // 429 / 5xx は retry
+                *status == 429 || (*status >= 500 && *status <= 599) || *status == 408
+            }
+            GuardianNextError::Http(_) => true, // reqwest::Error（timeout/DNS等）を含む
+            _ => false,
+        }
+    }
+
+    fn backoff(&self, attempt: usize) -> Duration {
+        // 指数バックオフ（jitter 最小版：attempt 依存の微小揺らぎ）
+        let mut d = self.policy.base_delay * (1u32 << (attempt as u32)).min(8);
+        if d > self.policy.max_delay {
+            d = self.policy.max_delay;
+        }
+        // deterministic jitter (0..=50ms)
+        let jitter_ms = (attempt as u64 * 17) % 51;
+        d + Duration::from_millis(jitter_ms)
+    }
+
+    pub async fn run<F, Fut, T>(&self, mut f: F) -> Result<T, GuardianNextError>
+    where
+        F: FnMut(usize) -> Fut,
+        Fut: std::future::Future<Output = Result<T, GuardianNextError>>,
+    {
+        let mut last_err: Option<GuardianNextError> = None;
+
+        for attempt in 0..self.policy.max_attempts {
+            match f(attempt).await {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    let retry = Self::should_retry(&e) && attempt + 1 < self.policy.max_attempts;
+                    if !retry {
+                        return Err(e);
+                    }
+                    last_err = Some(e);
+                    sleep(self.backoff(attempt)).await;
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or(GuardianNextError::Internal(
+            "retry runner ended unexpectedly".into(),
+        )))
+    }
+}

--- a/crates/veil-guardian/src/guardian_next/net/singleflight.rs
+++ b/crates/veil-guardian/src/guardian_next/net/singleflight.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
+
+struct InFlight<V> {
+    notify: Arc<Notify>,
+    result: Arc<tokio::sync::Mutex<Option<V>>>,
+}
+
+#[derive(Clone)]
+pub struct SingleFlight<K, V> {
+    inner: Arc<Mutex<HashMap<K, InFlight<V>>>>,
+}
+
+impl<K, V> SingleFlight<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// 同一キーは先頭だけが producer を実行。後続は notify 待ち。
+    pub async fn do_call<F, Fut>(&self, key: K, producer: F) -> V
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = V>,
+    {
+        // fast path: 既にin-flightがある
+        let (notify, result_mutex, is_leader) = {
+            let mut map = self.inner.lock().unwrap();
+            if let Some(inf) = map.get(&key) {
+                (inf.notify.clone(), inf.result.clone(), false)
+            } else {
+                let inf = InFlight {
+                    notify: Arc::new(Notify::new()),
+                    result: Arc::new(tokio::sync::Mutex::new(None)),
+                };
+                let notify = inf.notify.clone();
+                let result = inf.result.clone();
+                map.insert(key.clone(), inf);
+                (notify, result, true)
+            }
+        };
+
+        if is_leader {
+            let v = producer().await;
+            {
+                let mut slot = result_mutex.lock().await;
+                *slot = Some(v.clone());
+            }
+            // map から削除して通知
+            {
+                let mut map = self.inner.lock().unwrap();
+                map.remove(&key);
+            }
+            notify.notify_waiters();
+            v
+        } else {
+            notify.notified().await;
+            let slot = result_mutex.lock().await;
+            slot.clone().expect("singleflight: notified but no result")
+        }
+    }
+}
+
+impl<K, V> Default for SingleFlight<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/veil-guardian/src/guardian_next/outcome.rs
+++ b/crates/veil-guardian/src/guardian_next/outcome.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchOutcome {
+    CacheHitFresh,
+    CacheHitStale,
+    CacheHitStaleFallback,
+    NetworkFetched,
+    NetworkNotModified,
+    OfflineUsedFreshCache,
+    OfflineFallbackUsedStale,
+    FailedNoUsableCache,
+}
+
+/// Human readable label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutcomeLabel(pub String);
+
+impl OutcomeLabel {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+pub fn outcome_label(outcome: FetchOutcome) -> OutcomeLabel {
+    let s = match outcome {
+        FetchOutcome::CacheHitFresh => "Hit (Fresh)",
+        FetchOutcome::OfflineUsedFreshCache => "Hit (Fresh)",
+        FetchOutcome::CacheHitStale => "Hit (Stale)",
+        FetchOutcome::CacheHitStaleFallback => "Hit (Stale) [Fallback]",
+        FetchOutcome::OfflineFallbackUsedStale => "Hit (Stale) [Offline Fallback]",
+        FetchOutcome::NetworkFetched => "Fetched",
+        FetchOutcome::NetworkNotModified => "Hit (Fresh) [304]",
+        FetchOutcome::FailedNoUsableCache => "Miss (No Cache)",
+    };
+    OutcomeLabel(s.to_string())
+}

--- a/crates/veil-guardian/src/guardian_next/types.rs
+++ b/crates/veil-guardian/src/guardian_next/types.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, SystemTime};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CacheKey(pub String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheFreshness {
+    Fresh,
+    StaleUsable,
+    Expired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheMeta {
+    pub schema: u32,
+    pub key: String,
+    pub fetched_at_unix: u64, // epoch seconds
+    pub ttl_seconds: u64,
+    pub etag: Option<String>,
+}
+
+impl CacheMeta {
+    pub fn new(key: CacheKey, now: SystemTime, ttl_seconds: u64, etag: Option<String>) -> Self {
+        let fetched_at_unix = now
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+        Self {
+            schema: 1,
+            key: key.0,
+            fetched_at_unix,
+            ttl_seconds,
+            etag,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheEntry<T> {
+    pub meta: CacheMeta,
+    pub payload: T,
+}
+
+impl<T> CacheEntry<T> {
+    pub fn fetched_at(&self) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(self.meta.fetched_at_unix)
+    }
+
+    pub fn ttl(&self) -> Duration {
+        Duration::from_secs(self.meta.ttl_seconds)
+    }
+
+    pub fn age(&self, now: SystemTime) -> Duration {
+        now.duration_since(self.fetched_at())
+            .unwrap_or(Duration::ZERO)
+    }
+
+    pub fn freshness(&self, now: SystemTime, grace: Duration) -> CacheFreshness {
+        let age = self.age(now);
+        if age <= self.ttl() {
+            CacheFreshness::Fresh
+        } else if age <= self.ttl() + grace {
+            CacheFreshness::StaleUsable
+        } else {
+            CacheFreshness::Expired
+        }
+    }
+}

--- a/crates/veil-guardian/src/lib.rs
+++ b/crates/veil-guardian/src/lib.rs
@@ -1,10 +1,12 @@
 // Re-export public API
 pub mod db;
+pub mod guardian_next;
 pub mod metrics;
 pub mod models;
 pub mod providers;
 pub mod report;
 pub mod scanner;
+pub mod util;
 
 pub use db::GuardianDb;
 pub use db::GuardianError;

--- a/crates/veil-guardian/src/providers/osv/mod.rs
+++ b/crates/veil-guardian/src/providers/osv/mod.rs
@@ -2,5 +2,6 @@ pub mod cache;
 pub mod client;
 pub mod details;
 pub mod details_store;
+pub mod net;
 
 pub use client::OsvClient;

--- a/crates/veil-guardian/src/providers/osv/net/mod.rs
+++ b/crates/veil-guardian/src/providers/osv/net/mod.rs
@@ -1,0 +1,33 @@
+pub mod retry;
+pub mod sleeper;
+pub mod timeout;
+
+pub use retry::*;
+pub use sleeper::*;
+pub use timeout::*;
+
+// v0.11.5: concurrency gate (shared impl lives in guardian_next)
+pub use crate::guardian_next::net::concurrency::{ConcurrencyGate, ConcurrencyPolicy};
+
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct NetConfig {
+    pub connect_timeout: Duration,
+    pub per_request_timeout: Duration,
+    pub total_budget: Duration,
+    pub retry: retry::RetryPolicy,
+    pub concurrency: ConcurrencyPolicy,
+}
+
+impl Default for NetConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout: Duration::from_secs(2),
+            per_request_timeout: Duration::from_secs(8),
+            total_budget: Duration::from_secs(20),
+            retry: retry::RetryPolicy::default(),
+            concurrency: ConcurrencyPolicy { max_in_flight: 8 },
+        }
+    }
+}

--- a/crates/veil-guardian/src/providers/osv/net/retry.rs
+++ b/crates/veil-guardian/src/providers/osv/net/retry.rs
@@ -1,0 +1,101 @@
+use reqwest::header::HeaderMap;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    pub max_attempts: usize,
+    pub base_delay: Duration,
+    pub max_delay: Duration,
+    pub jitter_factor: f64,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            base_delay: Duration::from_millis(200),
+            max_delay: Duration::from_secs(2),
+            jitter_factor: 0.2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryClass {
+    Success,
+    RetryAfter(Duration),
+    Backoff,
+    Fatal,
+}
+
+pub fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
+    let v = headers.get("retry-after")?.to_str().ok()?;
+    let secs: u64 = v.parse().ok()?;
+    Some(Duration::from_secs(secs))
+}
+
+pub fn classify_response(status: u16, headers: &HeaderMap) -> RetryClass {
+    if (200..300).contains(&status) || status == 304 {
+        return RetryClass::Success;
+    }
+
+    if status == 429 || status == 503 {
+        if let Some(d) = parse_retry_after(headers) {
+            return RetryClass::RetryAfter(d);
+        }
+        return RetryClass::Backoff;
+    }
+
+    if status == 408 || (500..600).contains(&status) {
+        return RetryClass::Backoff;
+    }
+
+    RetryClass::Fatal
+}
+
+pub fn classify_error(e: &reqwest::Error) -> RetryClass {
+    if e.is_timeout() || e.is_connect() {
+        return RetryClass::Backoff;
+    }
+    if e.is_builder() {
+        return RetryClass::Fatal;
+    }
+    RetryClass::Backoff
+}
+
+pub fn backoff_delay(policy: &RetryPolicy, attempt: usize) -> Duration {
+    let pow = 1u32
+        .checked_shl((attempt.saturating_sub(1)) as u32)
+        .unwrap_or(u32::MAX);
+    let raw = policy.base_delay.saturating_mul(pow);
+    let capped = raw.min(policy.max_delay);
+    apply_jitter(capped, policy.jitter_factor)
+}
+
+fn apply_jitter(delay: Duration, jitter_factor: f64) -> Duration {
+    if jitter_factor <= 0.0 {
+        return delay;
+    }
+
+    let nanos = delay.as_nanos() as f64;
+    let span = nanos * jitter_factor; // ±span
+    let r = pseudo_rand_0_1();
+    let offset = (r * 2.0 - 1.0) * span;
+    let out = (nanos + offset).max(0.0);
+    Duration::from_nanos(out as u64)
+}
+
+fn pseudo_rand_0_1() -> f64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let t = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .to_le_bytes();
+
+    let h = blake3::hash(&t);
+    let mut b = [0u8; 8];
+    b.copy_from_slice(&h.as_bytes()[..8]);
+    let u = u64::from_le_bytes(b);
+    (u as f64) / (u64::MAX as f64)
+}

--- a/crates/veil-guardian/src/providers/osv/net/sleeper.rs
+++ b/crates/veil-guardian/src/providers/osv/net/sleeper.rs
@@ -1,0 +1,40 @@
+use async_trait::async_trait;
+use std::sync::Mutex;
+use std::time::Duration;
+
+#[async_trait]
+pub trait Sleeper: Send + Sync + 'static {
+    async fn sleep(&self, duration: Duration);
+}
+
+pub struct TokioSleeper;
+
+#[async_trait]
+impl Sleeper for TokioSleeper {
+    async fn sleep(&self, duration: Duration) {
+        tokio::time::sleep(duration).await;
+    }
+}
+
+/// For testing: matches user specification accurately
+#[derive(Default)]
+pub struct RecordingSleeper {
+    sleeps: Mutex<Vec<Duration>>,
+}
+
+impl RecordingSleeper {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn sleeps(&self) -> Vec<Duration> {
+        self.sleeps.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Sleeper for RecordingSleeper {
+    async fn sleep(&self, duration: Duration) {
+        self.sleeps.lock().unwrap().push(duration);
+    }
+}

--- a/crates/veil-guardian/src/providers/osv/net/timeout.rs
+++ b/crates/veil-guardian/src/providers/osv/net/timeout.rs
@@ -1,0 +1,24 @@
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub struct TimeBudget {
+    deadline: Instant,
+}
+
+impl TimeBudget {
+    pub fn new(total: Duration) -> Self {
+        Self {
+            deadline: Instant::now() + total,
+        }
+    }
+
+    pub fn remaining(&self) -> Option<Duration> {
+        self.deadline.checked_duration_since(Instant::now())
+    }
+}
+
+/// Returns the shorter of `per_request` or `budget.remaining()`.
+/// If no budget remains, returns None.
+pub fn clamp_timeout(budget: &TimeBudget, per_request: Duration) -> Option<Duration> {
+    budget.remaining().map(|rem| rem.min(per_request))
+}

--- a/crates/veil-guardian/src/report.rs
+++ b/crates/veil-guardian/src/report.rs
@@ -122,7 +122,7 @@ impl ScanResult {
                             has_cache_info = true;
                         }
                         match advisory.cache_status.as_deref() {
-                            Some("Network") => stats_network += 1,
+                            Some("Network") | Some("Fetched") => stats_network += 1,
                             Some(s) if s.contains("Fresh") => stats_hit_fresh += 1, // "Hit (Fresh)"
                             Some(s) if s.contains("Stale") => stats_hit_stale += 1, // "Hit (Stale)"
                             Some(s) if s.starts_with("Error") => stats_error += 1,

--- a/crates/veil-guardian/src/util/atomic_write.rs
+++ b/crates/veil-guardian/src/util/atomic_write.rs
@@ -1,0 +1,95 @@
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Writes bytes to a file atomically.
+///
+/// 1. Creates a unique temporary file in the same directory.
+/// 2. Writes data, flushes, and syncs.
+/// 3. Renames the temporary file to the target path.
+///    On Windows, if the target exists, it attempts to remove it first before renaming to simulate atomic overwrite.
+/// 4. Cleans up the temporary file on failure.
+pub fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    // Try a few times to create a unique temporary file
+    for _ in 0..3 {
+        let tmp_path = unique_tmp_path(path);
+        match write_and_rename(&tmp_path, path, bytes) {
+            Ok(_) => return Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue, // Collision, retry with new name
+            Err(e) => {
+                // Best-effort cleanup
+                let _ = fs::remove_file(&tmp_path);
+                return Err(e);
+            }
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "failed to create unique temporary file after retries",
+    ))
+}
+
+fn unique_tmp_path(path: &Path) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+
+    // .<filename>.tmp.<pid>.<nanos>
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+
+    let tmp_name = format!(".{}.tmp.{}.{}", file_name, pid, nanos);
+    path.with_file_name(tmp_name)
+}
+
+fn write_and_rename(tmp_path: &Path, target_path: &Path, bytes: &[u8]) -> io::Result<()> {
+    // Open with create_new(true) to ensure uniqueness/no-clobber of existing tmp
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(tmp_path)?;
+
+    file.write_all(bytes)?;
+    file.flush()?;
+    file.sync_all()?;
+
+    // Rename
+    // On Unix, rename is atomic replacing destination.
+    // On Windows, rename fails if destination exists.
+    #[cfg(unix)]
+    {
+        fs::rename(tmp_path, target_path)?;
+    }
+
+    #[cfg(windows)]
+    {
+        // Windows atomic-ish replacement: remove dest then rename.
+        // There is a race window here, but it's better than failing.
+        // v0.11.7 lock will fix the race.
+        if target_path.exists() {
+            let _ = fs::remove_file(target_path);
+        }
+        fs::rename(tmp_path, target_path)?;
+    }
+
+    // Non-unix/windows fallback (e.g. wasm? unlikely for this crate but safe default)
+    #[cfg(not(any(unix, windows)))]
+    {
+        if target_path.exists() {
+            let _ = fs::remove_file(target_path);
+        }
+        fs::rename(tmp_path, target_path)?;
+    }
+
+    Ok(())
+}

--- a/crates/veil-guardian/src/util/file_lock.rs
+++ b/crates/veil-guardian/src/util/file_lock.rs
@@ -1,0 +1,39 @@
+use fs2::FileExt;
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::path::Path;
+
+/// Executes an operation with an exclusive lock on a separate lock file.
+///
+/// The lock file is created at `<path>.lock`.
+/// Drops the lock automatically when the file handle goes out of scope.
+pub fn with_file_lock<F, T>(path: &Path, op: F) -> io::Result<T>
+where
+    F: FnOnce() -> io::Result<T>,
+{
+    // Use .lock extension appended to the full file name/path
+    // e.g. "cache.json" -> "cache.json.lock"
+    let lock_path_noun = format!("{}.lock", path.display());
+    let lock_path = Path::new(&lock_path_noun);
+
+    // Ensure parent exists
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(lock_path)?;
+
+    file.lock_exclusive()?;
+
+    let result = op();
+
+    // Lock is released when `file` is dropped.
+    drop(file);
+
+    result
+}

--- a/crates/veil-guardian/src/util/key.rs
+++ b/crates/veil-guardian/src/util/key.rs
@@ -1,0 +1,48 @@
+// use blake3::Hash;
+
+/// Normalizes a key for use as a filename.
+///
+/// Rules:
+/// 1. Allowed characters: `[A-Za-z0-9._-]`. All others are replaced with `_`.
+/// 2. If the key contains unsafe characters (i.e. was modified by rule 1), a hash of the *original* key is appended
+///    to prevent collisions (e.g. `foo:bar` vs `foo_bar`).
+/// 3. If the normalized string exceeds `MAX_LEN` (128), it is truncated to `TRUNC_LEN` (64) and the hash is appended.
+///
+/// The hash format is `{prefix}-{hash_hex}`.
+/// Hash used is BLAKE3 (first 16 hex chars).
+pub fn normalize_key(key: &str) -> String {
+    const MAX_LEN: usize = 128;
+    const TRUNC_LEN: usize = 64;
+
+    let mut safe_str = String::with_capacity(key.len());
+    let mut modified = false;
+
+    for c in key.chars() {
+        if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+            safe_str.push(c);
+        } else {
+            safe_str.push('_');
+            modified = true;
+        }
+    }
+
+    // append hash if modified to avoid collision (injectivity)
+    // or if length exceeds limit
+    if modified || safe_str.len() > MAX_LEN {
+        // Hash original key
+        let hash = blake3::hash(key.as_bytes());
+        let hash_hex = hash.to_hex(); // 64 chars
+        let short_hash = &hash_hex[..16]; // 16 chars enough for collision resistance in this context
+
+        let prefix_len = if safe_str.len() > TRUNC_LEN {
+            TRUNC_LEN
+        } else {
+            safe_str.len()
+        };
+
+        let prefix = &safe_str[..prefix_len];
+        format!("{}-{}", prefix, short_hash)
+    } else {
+        safe_str
+    }
+}

--- a/crates/veil-guardian/src/util/mod.rs
+++ b/crates/veil-guardian/src/util/mod.rs
@@ -1,0 +1,3 @@
+pub mod atomic_write;
+pub mod file_lock;
+pub mod key;

--- a/crates/veil-guardian/tests/atomic_write.rs
+++ b/crates/veil-guardian/tests/atomic_write.rs
@@ -1,0 +1,59 @@
+use std::fs;
+use tempfile::tempdir;
+use veil_guardian::util::atomic_write::atomic_write_bytes;
+
+#[test]
+fn test_atomic_write_creates_file() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("test.txt");
+    let content = b"Hello world";
+
+    atomic_write_bytes(&file, content).unwrap();
+
+    let read_back = fs::read(&file).unwrap();
+    assert_eq!(read_back, content);
+}
+
+#[test]
+fn test_atomic_write_overwrites_existing() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("overwrite.txt");
+
+    atomic_write_bytes(&file, b"First").unwrap();
+    assert_eq!(fs::read(&file).unwrap(), b"First");
+
+    atomic_write_bytes(&file, b"Second").unwrap();
+    assert_eq!(fs::read(&file).unwrap(), b"Second");
+}
+
+#[test]
+fn test_atomic_write_creates_parent_dir() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("nested").join("deep").join("test.txt");
+    let content = b"Deep";
+
+    atomic_write_bytes(&file, content).unwrap();
+
+    let read_back = fs::read(&file).unwrap();
+    assert_eq!(read_back, content);
+}
+
+#[test]
+fn test_no_tmp_leftovers() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("clean.txt");
+
+    atomic_write_bytes(&file, b"clean").unwrap();
+
+    // Check for any files starting with .clean.txt.tmp
+    let entries = fs::read_dir(dir.path()).unwrap();
+    let count = entries
+        .filter_map(Result::ok)
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            name.contains(".clean.txt.tmp")
+        })
+        .count();
+
+    assert_eq!(count, 0, "Should have 0 tmp files left");
+}

--- a/crates/veil-guardian/tests/file_lock.rs
+++ b/crates/veil-guardian/tests/file_lock.rs
@@ -1,0 +1,60 @@
+use serde_json::Value;
+use std::fs;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use tempfile::tempdir;
+use veil_guardian::util::atomic_write::atomic_write_bytes;
+use veil_guardian::util::file_lock::with_file_lock;
+
+#[test]
+fn test_concurrent_writes_are_safe() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("concurrent.json");
+    let file_arc = Arc::new(file);
+
+    let n = 20;
+    let barrier = Arc::new(Barrier::new(n));
+    let mut handles = Vec::with_capacity(n);
+
+    for i in 0..n {
+        let f = file_arc.clone();
+        let b = barrier.clone();
+        handles.push(thread::spawn(move || {
+            b.wait();
+            with_file_lock(&f, || {
+                // Write valid JSON with an index, enough content to risk tearing if not atomic/locked
+                let content = serde_json::json!({
+                    "writer": i,
+                    "payload": "x".repeat(1000)
+                });
+                let bytes = serde_json::to_vec(&content).unwrap();
+                // We use atomic write inside lock, matching Stores
+                atomic_write_bytes(&f, &bytes)
+            })
+            .unwrap();
+        }));
+    }
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Verify content is valid JSON (no partial/corrupt write)
+    let content = fs::read_to_string(&*file_arc).unwrap();
+    let json: Value = serde_json::from_str(&content).expect("JSON should be valid");
+
+    // Check that writer is one of 0..n
+    let writer = json["writer"].as_u64().unwrap();
+    assert!(writer < n as u64, "Writer index {} invalid", writer);
+    assert_eq!(json["payload"].as_str().unwrap().len(), 1000);
+}
+
+#[test]
+fn test_lock_file_creation() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("data.json");
+
+    with_file_lock(&file, || Ok(())).unwrap();
+
+    assert!(dir.path().join("data.json.lock").exists());
+}

--- a/crates/veil-guardian/tests/guardian_next_retry.rs
+++ b/crates/veil-guardian/tests/guardian_next_retry.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+use veil_guardian::guardian_next::net::ReqwestHttpClient;
+use veil_guardian::guardian_next::{GuardianNext, GuardianNextConfig};
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn retry_on_500_then_success() {
+    let server = MockServer::start().await;
+
+    // 1回目 500
+    // 2回目 200 (Default Fallback - Low Priority via LIFO)
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/GHSA-TEST"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"id":"GHSA-TEST"})),
+        )
+        .mount(&server)
+        .await;
+
+    // 1回目 500 (High Priority via LIFO)
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/GHSA-TEST"))
+        .respond_with(ResponseTemplate::new(500))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // Create temporary cache dir
+    let tmp_dir = tempfile::tempdir().unwrap();
+
+    let cfg = GuardianNextConfig {
+        offline: false,
+        http_timeout_ms: 2000,
+        cache_dir: tmp_dir.path().to_path_buf(),
+        ..Default::default()
+    };
+
+    let http = Arc::new(ReqwestHttpClient::new().unwrap());
+    let g = GuardianNext::new(cfg, http).unwrap();
+
+    // Since GuardianNext uses hardcoded URL in `get_osv_details_json` (api.osv.dev),
+    // we cannot easily test it with wiremock unless we modify GuardianNext to accept base URL or use `get_json_with_policy`.
+    // But `get_json_with_policy` is private.
+    // However, `get_osv_details_json` is the public API.
+    // For this test to work without modifying `GuardianNext`, we would need to mock `HttpClient`.
+    // But we are using `ReqwestHttpClient`.
+    //
+    // Option A: Make `get_json_with_policy` public for crate or tests.
+    // Option B: Implementing a MockHttpClient that delegates to wiremock? No, wiremock is HTTP server.
+    // Option C: Changing `GuardianNext` to accept a base_url in config or constructor used for OSV.
+
+    // The user's provided test code used:
+    // let url = format!("{}/v1/vulns/GHSA-TEST", &server.uri());
+    // let key = ...
+    // let (payload, _) = g.get_json_with_policy(&key, &url).await.unwrap();
+
+    // But `get_json_with_policy` is private in the provided code snippet.
+    // I should make `get_json_with_policy` `pub(crate)` in `fetcher.rs`.
+    // I will Assume I made it pub(crate) (I need to update `fetcher.rs`).
+
+    let url = format!("{}/v1/vulns/GHSA-TEST", &server.uri());
+    let key = veil_guardian::guardian_next::CacheKey("osv:vuln:GHSA-TEST".into());
+
+    let (payload, _outcome) = g.get_json_with_policy(&key, &url).await.unwrap();
+
+    assert_eq!(payload["id"], "GHSA-TEST");
+}

--- a/crates/veil-guardian/tests/guardian_next_singleflight.rs
+++ b/crates/veil-guardian/tests/guardian_next_singleflight.rs
@@ -1,0 +1,35 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use veil_guardian::guardian_next::net::SingleFlight;
+use veil_guardian::guardian_next::CacheKey;
+
+#[tokio::test]
+async fn singleflight_runs_only_once() {
+    let sf: SingleFlight<CacheKey, usize> = SingleFlight::new();
+    let calls = Arc::new(AtomicUsize::new(0));
+
+    let key = CacheKey("k".into());
+    let mut tasks = vec![];
+
+    for _ in 0..10 {
+        let sf2 = sf.clone();
+        let k2 = key.clone();
+        let c2 = calls.clone();
+        tasks.push(tokio::spawn(async move {
+            sf2.do_call(k2, move || async move {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                c2.fetch_add(1, Ordering::SeqCst);
+                42
+            })
+            .await
+        }));
+    }
+
+    let results = futures::future::join_all(tasks).await;
+    for r in results {
+        assert_eq!(r.unwrap(), 42);
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}

--- a/crates/veil-guardian/tests/key_versioning.rs
+++ b/crates/veil-guardian/tests/key_versioning.rs
@@ -1,0 +1,108 @@
+use serde_json::json;
+use std::fs;
+use std::time::SystemTime;
+use tempfile::tempdir;
+use veil_guardian::providers::osv::details::CachedVuln;
+use veil_guardian::providers::osv::details_store::DetailsStore;
+use veil_guardian::util::key::normalize_key;
+
+#[test]
+fn test_normalize_key_safe_chars() {
+    let key = "GHSA-aaaa-bbbb";
+    // safe chars are unchanged
+    assert_eq!(normalize_key(key), "GHSA-aaaa-bbbb");
+}
+
+#[test]
+fn test_normalize_key_collision_avoidance() {
+    let key1 = "foo:bar";
+    let key2 = "foo_bar";
+
+    let n1 = normalize_key(key1);
+    let n2 = normalize_key(key2);
+
+    // key1 converts to foo_bar but has modified=true, so it gets hash suffix
+    // key2 is safe, so it stays foo_bar
+    // Therefore n1 != n2
+    assert_ne!(n1, n2);
+    assert!(n1.starts_with("foo_bar-"));
+    assert_eq!(n2, "foo_bar");
+}
+
+#[test]
+fn test_normalize_key_truncation() {
+    let long_key = "a".repeat(200);
+    let normalized = normalize_key(&long_key);
+
+    assert!(normalized.len() < 200);
+    assert!(normalized.len() <= 128 + 20); // rough upper bound
+                                           // should be 64 char prefix + '-' + 16 char hash = 81 chars
+    assert_eq!(normalized.len(), 64 + 1 + 16);
+    assert!(normalized.starts_with(&"a".repeat(64)));
+}
+
+#[test]
+fn test_legacy_fallback() {
+    let dir = tempdir().unwrap();
+    let store = DetailsStore::with_dir(dir.path()).unwrap();
+
+    let id = "GHSA-legacy-123";
+    let entry = CachedVuln::new(id, SystemTime::now(), json!({"id": id}), None);
+    let body = serde_json::to_string(&entry).unwrap();
+
+    // 1. Manually write to legacy path
+    // Legacy path uses simple sanitize (replace : with _ etc), but GHSA-legacy-123 is safe
+    let legacy_path = dir.path().join(format!("{}.json", id));
+    fs::write(&legacy_path, body).unwrap();
+
+    // 2. Load via store - should find it in legacy
+    let loaded = store.load(id).expect("Should fallback to legacy");
+    assert_eq!(loaded.vuln_id, id);
+
+    // 3. Save via store - should write to v1
+    store.save(&loaded).unwrap();
+
+    // 4. Verify v1 file exists
+    // GHSA-legacy-123 is safe, so v1 name is same
+    // But it's in v1 subdirectory
+    let v1_path = dir.path().join("v1").join(format!("{}.json", id));
+    assert!(v1_path.exists());
+
+    // 5. Load again - assumes v1 is read
+    // Modify v1 to prove it's being read
+    let mut modified = entry.clone();
+    modified.vuln = json!({"id": "modified"});
+    let mod_body = serde_json::to_string(&modified).unwrap();
+    fs::write(&v1_path, mod_body).unwrap();
+
+    let reloaded = store.load(id).unwrap();
+    assert_eq!(reloaded.vuln["id"], "modified");
+}
+
+#[test]
+fn test_complex_id_roundtrip() {
+    let dir = tempdir().unwrap();
+    let store = DetailsStore::with_dir(dir.path()).unwrap();
+
+    let id = "GHSA/complex:id";
+    let entry = CachedVuln::new(id, SystemTime::now(), json!({"id": id}), None);
+
+    // Save
+    store.save(&entry).unwrap();
+
+    // Check file exists in v1 with hashed name
+    // normalized: GHSA_complex_id-<hash>
+    let v1_entries: Vec<_> = fs::read_dir(dir.path().join("v1"))
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .filter(|name| name.ends_with(".json") && !name.ends_with(".lock"))
+        .collect();
+
+    assert!(!v1_entries.is_empty(), "Should have found json file");
+    assert!(v1_entries[0].starts_with("GHSA_complex_id-"));
+    assert!(v1_entries[0].ends_with(".json"));
+
+    // Load
+    let loaded = store.load(id).unwrap();
+    assert_eq!(loaded.vuln_id, id);
+}

--- a/crates/veil-guardian/tests/osv_concurrency.rs
+++ b/crates/veil-guardian/tests/osv_concurrency.rs
@@ -1,0 +1,93 @@
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Barrier};
+use std::time::Duration;
+use tempfile::tempdir;
+use veil_guardian::providers::osv::{
+    details_store::DetailsStore,
+    net::{NetConfig, Sleeper, TokioSleeper},
+    OsvClient,
+};
+use veil_guardian::Metrics;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[test]
+fn respects_max_in_flight_concurrency_gate() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let (mock, url) = rt.block_on(async {
+        let mock = MockServer::start().await;
+        let url = mock.uri();
+
+        // Prepare delayed responses to create overlap.
+        let n = 20usize;
+        for i in 0..n {
+            let id = format!("OSV-TEST-{}", i);
+            Mock::given(method("GET"))
+                .and(path(format!("/vulns/{}", id)))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_delay(Duration::from_millis(200))
+                        .set_body_json(serde_json::json!({ "id": id })),
+                )
+                .mount(&mock)
+                .await;
+        }
+        (mock, url)
+    });
+
+    let dir = tempdir().unwrap();
+    let store = DetailsStore::new(Some(dir.path().to_path_buf()));
+
+    let metrics = Arc::new(Metrics::new());
+
+    let mut net = NetConfig::default();
+    net.concurrency.max_in_flight = 2;
+    // OsvClient uses its own runtime, so we are fine.
+
+    let sleeper: Arc<dyn Sleeper> = Arc::new(TokioSleeper);
+
+    let client = Arc::new(OsvClient::new_custom_with_net_and_metrics(
+        false,
+        store,
+        Some(url),
+        net,
+        sleeper,
+        Some(metrics.clone()),
+    ));
+
+    let n = 20usize;
+    let mut handles = Vec::with_capacity(n);
+
+    // Use barriers to sync start if possible, but standard threads + OsvClient (blocking) is simple.
+    let barrier = Arc::new(Barrier::new(n));
+
+    for i in 0..n {
+        let id = format!("OSV-TEST-{}", i);
+        let c = client.clone();
+        let b = barrier.clone();
+        handles.push(std::thread::spawn(move || {
+            b.wait();
+            let _ = c.fetch_vuln_details(&id);
+        }));
+    }
+
+    for h in handles {
+        let _ = h.join();
+    }
+
+    let max = metrics.max_concurrency.load(Ordering::Relaxed);
+    assert!(
+        max <= 2,
+        "max_concurrency exceeded max_in_flight: max_concurrency={}, max_in_flight=2",
+        max
+    );
+
+    // Ensure mock stays alive until here
+    drop(mock);
+}

--- a/crates/veil-guardian/tests/osv_retry.rs
+++ b/crates/veil-guardian/tests/osv_retry.rs
@@ -1,0 +1,172 @@
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+use veil_guardian::providers::osv::{
+    details_store::DetailsStore,
+    net::{NetConfig, RecordingSleeper, RetryPolicy},
+    OsvClient,
+};
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[tokio::test]
+async fn retry_on_500_records_backoff_sleeps() {
+    let mock = MockServer::start().await;
+    let url = mock.uri(); // Clean URL, OsvClient handles path
+
+    // OsvClient expects base URL without /querybatch if possible, or handles logic.
+    // The client code:
+    // if base_url.ends_with("/querybatch") { replace } else { split/format }
+    // If we pass mock.uri() which is e.g. http://127.0.0.1:xxx
+    // It appends /vulns/{id}
+
+    let dir = tempdir().unwrap();
+
+    let id = "GHSA-retry-500".to_string();
+
+    Mock::given(method("GET"))
+        .and(path(format!("/vulns/{}", id)))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(3) // 3 attempts (initial + 2 retries)
+        .mount(&mock)
+        .await;
+
+    let sleeper = Arc::new(RecordingSleeper::new());
+
+    let net = NetConfig {
+        retry: RetryPolicy {
+            max_attempts: 3,
+            base_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(1),
+            jitter_factor: 0.0,
+        },
+        total_budget: Duration::from_secs(10),
+        ..Default::default()
+    };
+
+    let id2 = id.clone();
+    let url2 = url.clone();
+    let sleeper2 = sleeper.clone();
+
+    // Run in blocking thread as OsvClient is sync-bridged internally for `fetch_vuln_details`
+    let result = tokio::task::spawn_blocking(move || {
+        // We need to use new_custom_with_net which is sync? No, it's just a constructor.
+        // OsvClient::new_custom_with_net returns Self.
+        let store = DetailsStore::new(Some(dir.path().to_path_buf()));
+        let client = OsvClient::new_custom_with_net(false, store, Some(url2), net, sleeper2);
+        client.fetch_vuln_details(&id2)
+    })
+    .await
+    .unwrap();
+
+    assert!(result.is_err());
+    let sleeps = sleeper.sleeps();
+    assert_eq!(sleeps.len(), 2);
+    // 1st retry: 100ms * 2^0 = 100ms
+    // 2nd retry: 100ms * 2^1 = 200ms
+    assert_eq!(sleeps[0], Duration::from_millis(100));
+    assert_eq!(sleeps[1], Duration::from_millis(200));
+}
+
+#[tokio::test]
+async fn retry_after_is_respected() {
+    let mock = MockServer::start().await;
+    let url = mock.uri();
+    let dir = tempdir().unwrap();
+
+    let id = "GHSA-retry-429".to_string();
+
+    // First request returns 429 with Retry-After: 2
+    // Second request returns 200 OK (simulated, though here we verify failure behavior or success)
+
+    // If we want to simulate success after retry:
+    Mock::given(method("GET"))
+        .and(path(format!("/vulns/{}", id)))
+        .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "2"))
+        .up_to_n_times(1)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/vulns/{}", id)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": id,
+            "modified": "2021-01-01T00:00:00Z"
+        })))
+        .mount(&mock)
+        .await;
+
+    // Wait, if we only mount 429, it will keep returning 429.
+    // If we want to verify it slept 2s and retried.
+
+    let sleeper = Arc::new(RecordingSleeper::new());
+    let net = NetConfig {
+        retry: RetryPolicy {
+            max_attempts: 2, // Initial + 1 retry
+            jitter_factor: 0.0,
+            ..Default::default()
+        },
+        total_budget: Duration::from_secs(10),
+        ..Default::default()
+    };
+
+    let id2 = id.clone();
+    let url2 = url.clone();
+    let sleeper2 = sleeper.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        let store = DetailsStore::new(Some(dir.path().to_path_buf()));
+        let client = OsvClient::new_custom_with_net(false, store, Some(url2), net, sleeper2);
+        client.fetch_vuln_details(&id2)
+    })
+    .await
+    .unwrap();
+
+    assert!(result.is_ok()); // Should succeed after retry
+    let sleeps = sleeper.sleeps();
+    // Should have slept once for 2 seconds
+    assert_eq!(sleeps, vec![Duration::from_secs(2)]);
+}
+
+#[tokio::test]
+async fn retry_after_exceeds_budget_fails_fast() {
+    let mock = MockServer::start().await;
+    let url = mock.uri();
+    let dir = tempdir().unwrap();
+
+    let id = "GHSA-budget".to_string();
+    Mock::given(method("GET"))
+        .and(path(format!("/vulns/{}", id)))
+        .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "99"))
+        .mount(&mock)
+        .await;
+
+    let sleeper = Arc::new(RecordingSleeper::new());
+    let net = NetConfig {
+        total_budget: Duration::from_secs(1),
+        retry: RetryPolicy {
+            max_attempts: 3,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let id2 = id.clone();
+    let url2 = url.clone();
+    let sleeper2 = sleeper.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        let store = DetailsStore::new(Some(dir.path().to_path_buf()));
+        let client = OsvClient::new_custom_with_net(false, store, Some(url2), net, sleeper2);
+        client.fetch_vuln_details(&id2)
+    })
+    .await
+    .unwrap();
+
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("budget exceeded"));
+    assert!(sleeper.sleeps().is_empty()); // Should NOT sleep if budget exceeded
+}

--- a/crates/veil-guardian/tests/snapshots/report_output__report_output_deterministic.snap
+++ b/crates/veil-guardian/tests/snapshots/report_output__report_output_deterministic.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/veil-guardian/tests/report_output.rs
-assertion_line: 125
 expression: normalized
 ---
 Found 2 vulnerabilities in 2 packages scanned:
@@ -10,14 +9,14 @@ Cache: 0 fresh, 0 stale, 3 network, 0 offline, 0 error
   Locations: [TEMP]/package-lock.json
   [GHSA-1] Critical issue in A
     Fix: Upgrade to >= 1.0.1
-    Status: Network
+    Status: Fetched
 
   [GHSA-2] Medium issue in A
     Fix: No fixed version available (mitigation required)
-    Status: Network
+    Status: Fetched
 
 - b-lib v2.0.0 (npm)
   Locations: [TEMP]/package-lock.json
   [GHSA-3] Low issue in B
     Fix: No fixed version available (mitigation required)
-    Status: Network
+    Status: Fetched

--- a/crates/veil-guardian/tests/snapshots/report_output__report_output_duplicates.snap
+++ b/crates/veil-guardian/tests/snapshots/report_output__report_output_duplicates.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/veil-guardian/tests/report_output.rs
-assertion_line: 200
 expression: normalized
 ---
 Found 1 vulnerabilities in 1 packages scanned:
@@ -10,4 +9,4 @@ Cache: 0 fresh, 0 stale, 1 network, 0 offline, 0 error
   Locations: [TEMP]/package-lock.json
   [GHSA-1] Critical issue in A
     Fix: No fixed version available (mitigation required)
-    Status: Network
+    Status: Fetched

--- a/crates/veil-server/Cargo.toml
+++ b/crates/veil-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veil-server"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version.workspace = true
 

--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
         "Dogfooding",
         "dotenvy",
         "dtolnay",
+        "GHSA",
         "impls",
         "indicatif",
         "Luhn",
@@ -52,6 +53,7 @@
         "revwalk",
         "Roboto",
         "rustfmt",
+        "rustls",
         "rustpkgs",
         "Segoe",
         "sendgrid",
@@ -65,6 +67,7 @@
         "veil",
         "veri",
         "vulns",
-        "walkdir"
+        "walkdir",
+        "wiremock"
     ]
 }

--- a/docs/guardian/osv_details.md
+++ b/docs/guardian/osv_details.md
@@ -20,3 +20,14 @@ While the storage is raw, the `guardian` CLI performs a **best-effort extraction
 - `references`
 
 If a field is missing or malformed, it is simply omitted from the output rather than causing a crash or error.
+
+## Cache Resilience & Layout (v0.11.x)
+
+To ensure stability in high-concurrency environments (CI/CD) and against system crashes, the cache layer implements strict robustness guarantees:
+
+1.  **Atomic Writes**: JSON files are written to a temporary file, synced to disk, and atomically renamed. This prevents partial writes during power failures.
+2.  **File Locking**: Exclusive locks (`.lock` files) are used for all read/write operations, allowing safe parallel execution across multiple processes.
+3.  **Versioning**:
+    - **v1 Layout**: New cache entries are stored in a `v1` subdirectory with normalized filenames (e.g., `GHSA-foo-bar.json`).
+    - **Collision Avoidance**: Keys containing unsafe characters are hashed to prevent filename collisions.
+    - **Legacy Fallback**: The system transparently falls back to reading legacy cache paths if a v1 entry is missing, ensuring backward compatibility.


### PR DESCRIPTION
Summary
This PR completes the Guardian “Stability Track” for OSV integration. It makes external data fetching reliable and predictable under real-world conditions (offline, flaky networks, CI parallelism, and crashes).

What’s included

Cache Resilience

Atomic writes (tmp → sync → rename) to prevent partial/corrupted JSON on crashes

Multi-process file locking via .lock to ensure safe concurrent access

Versioned cache layout (v1/) with strict filename normalization and collision-avoidance hashing

Legacy read fallback for backward compatibility

Network Resilience

Retry policy with jittered exponential backoff

Retry-After header support

Strict time budgets (global + per-request)

Concurrency gate (max_in_flight: 8) to prevent OSV overload

Reporting

Fixed metrics aggregation for Fetched vs network traffic

Quality

cargo fmt, cargo clippy -D warnings, and full test suite passing

Snapshot updates where output changed intentionally

Testing

cargo test --workspace (all green)

New/updated tests:

tests/atomic_write.rs

tests/file_lock.rs

tests/key_versioning.rs

tests/osv_retry.rs

tests/osv_concurrency.rs

Notes

Cache writes now target v1/ by default. Reads fall back to legacy paths when needed, so existing caches remain usable without migration steps.