### PR TITLE
Add JP preset override resolver

### DIFF
--- a/crates/veil-config/presets/fintech-jp.toml
+++ b/crates/veil-config/presets/fintech-jp.toml
@@ -1,0 +1,11 @@
+[rules."pii.jp.mynumber.unlabeled"]
+enabled = true
+base_score = 72
+
+[rules."pii.fin.credit_card.keyword"]
+enabled = true
+base_score = 85
+
+[rules."pii.fin.bank_account.keyword"]
+enabled = true
+base_score = 80

--- a/crates/veil-config/presets/gov-jp.toml
+++ b/crates/veil-config/presets/gov-jp.toml
@@ -1,0 +1,11 @@
+[rules."pii.jp.mynumber.keyword"]
+enabled = true
+base_score = 92
+
+[rules."pii.jp.address.prefecture_heuristic"]
+enabled = true
+base_score = 55
+
+[rules."pii.person.name.keyword"]
+enabled = true
+base_score = 45

--- a/crates/veil-config/presets/logs-jp.toml
+++ b/crates/veil-config/presets/logs-jp.toml
@@ -1,0 +1,15 @@
+[rules."log.pii.jp.mynumber.keyword"]
+enabled = true
+base_score = 90
+
+[rules."log.pii.credit_card"]
+enabled = true
+base_score = 88
+
+[rules."log.pii.jp.phone.keyword"]
+enabled = true
+base_score = 70
+
+[rules."log.pii.jp.postal.keyword"]
+enabled = true
+base_score = 75

--- a/crates/veil-config/presets/si-vendor-jp.toml
+++ b/crates/veil-config/presets/si-vendor-jp.toml
@@ -1,0 +1,7 @@
+[rules."pii.jp.mynumber.keyword"]
+enabled = true
+base_score = 92
+
+[rules."pii.jp.address.prefecture_heuristic"]
+enabled = true
+base_score = 55

--- a/crates/veil-config/presets/standard-jp.toml
+++ b/crates/veil-config/presets/standard-jp.toml
@@ -1,0 +1,7 @@
+[rules."pii.jp.mynumber.keyword"]
+enabled = true
+base_score = 92
+
+[rules."pii.person.name.keyword"]
+enabled = true
+base_score = 45

--- a/crates/veil-config/src/config.rs
+++ b/crates/veil-config/src/config.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
@@ -14,15 +14,34 @@ pub struct Config {
     pub rules: HashMap<String, RuleConfig>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct OutputConfig {
-    #[serde(default)]
     pub mask_mode: Option<MaskMode>,
-    #[serde(default = "default_true")]
     pub show_snippets: bool,
     pub max_findings: Option<usize>,
-    #[serde(skip)]
     pub max_findings_is_set: bool,
+}
+
+impl Serialize for OutputConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let field_count = usize::from(self.mask_mode.is_some())
+            + 1
+            + usize::from(self.max_findings_is_set && self.max_findings.is_some());
+        let mut state = serializer.serialize_struct("OutputConfig", field_count)?;
+        if let Some(mask_mode) = self.mask_mode {
+            state.serialize_field("mask_mode", &mask_mode)?;
+        }
+        state.serialize_field("show_snippets", &self.show_snippets)?;
+        if self.max_findings_is_set {
+            if let Some(max_findings) = self.max_findings {
+                state.serialize_field("max_findings", &max_findings)?;
+            }
+        }
+        state.end()
+    }
 }
 
 impl Default for OutputConfig {
@@ -183,11 +202,9 @@ fn default_placeholder() -> String {
     "<REDACTED>".to_string()
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct RuleConfig {
-    #[serde(default = "default_true")]
     pub enabled: bool,
-    #[serde(skip)]
     pub enabled_is_set: bool,
     pub severity: Option<String>,
     pub pattern: Option<String>,
@@ -200,6 +217,64 @@ pub struct RuleConfig {
     pub validator: Option<String>,
     pub description: Option<String>,
     pub placeholder: Option<String>,
+}
+
+impl Serialize for RuleConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let field_count = usize::from(self.enabled_is_set)
+            + usize::from(self.severity.is_some())
+            + usize::from(self.pattern.is_some())
+            + usize::from(self.score.is_some())
+            + usize::from(self.category.is_some())
+            + usize::from(self.tags.is_some())
+            + usize::from(self.base_score.is_some())
+            + usize::from(self.context_lines_before.is_some())
+            + usize::from(self.context_lines_after.is_some())
+            + usize::from(self.validator.is_some())
+            + usize::from(self.description.is_some())
+            + usize::from(self.placeholder.is_some());
+        let mut state = serializer.serialize_struct("RuleConfig", field_count)?;
+        if self.enabled_is_set {
+            state.serialize_field("enabled", &self.enabled)?;
+        }
+        if let Some(severity) = &self.severity {
+            state.serialize_field("severity", severity)?;
+        }
+        if let Some(pattern) = &self.pattern {
+            state.serialize_field("pattern", pattern)?;
+        }
+        if let Some(score) = self.score {
+            state.serialize_field("score", &score)?;
+        }
+        if let Some(category) = &self.category {
+            state.serialize_field("category", category)?;
+        }
+        if let Some(tags) = &self.tags {
+            state.serialize_field("tags", tags)?;
+        }
+        if let Some(base_score) = self.base_score {
+            state.serialize_field("base_score", &base_score)?;
+        }
+        if let Some(context_lines_before) = self.context_lines_before {
+            state.serialize_field("context_lines_before", &context_lines_before)?;
+        }
+        if let Some(context_lines_after) = self.context_lines_after {
+            state.serialize_field("context_lines_after", &context_lines_after)?;
+        }
+        if let Some(validator) = &self.validator {
+            state.serialize_field("validator", validator)?;
+        }
+        if let Some(description) = &self.description {
+            state.serialize_field("description", description)?;
+        }
+        if let Some(placeholder) = &self.placeholder {
+            state.serialize_field("placeholder", placeholder)?;
+        }
+        state.end()
+    }
 }
 
 impl Default for RuleConfig {
@@ -370,6 +445,42 @@ max_findings = 1000
     }
 
     #[test]
+    fn serialize_omits_implicit_max_findings() {
+        let config: Config = toml::from_str(
+            r#"
+[output]
+show_snippets = true
+"#,
+        )
+        .unwrap();
+
+        let saved = toml::to_string(&config).unwrap();
+        let reparsed: Config = toml::from_str(&saved).unwrap();
+
+        assert!(!saved.contains("max_findings"));
+        assert_eq!(reparsed.output.max_findings, Some(1000));
+        assert!(!reparsed.output.max_findings_is_set);
+    }
+
+    #[test]
+    fn serialize_preserves_explicit_default_max_findings() {
+        let config: Config = toml::from_str(
+            r#"
+[output]
+max_findings = 1000
+"#,
+        )
+        .unwrap();
+
+        let saved = toml::to_string(&config).unwrap();
+        let reparsed: Config = toml::from_str(&saved).unwrap();
+
+        assert!(saved.contains("max_findings = 1000"));
+        assert_eq!(reparsed.output.max_findings, Some(1000));
+        assert!(reparsed.output.max_findings_is_set);
+    }
+
+    #[test]
     fn merge_combines_rule_fields_without_erasing_lower_layer_values() {
         let mut base = Config::default();
         base.rules.insert(
@@ -468,6 +579,45 @@ enabled = false
         base.merge(other);
 
         assert!(base.rules["pii.fin.credit_card.keyword"].enabled);
+    }
+
+    #[test]
+    fn serialize_omits_implicit_rule_enabled() {
+        let config: Config = toml::from_str(
+            r#"
+[rules."pii.fin.credit_card.keyword"]
+base_score = 85
+"#,
+        )
+        .unwrap();
+
+        let saved = toml::to_string(&config).unwrap();
+        let reparsed: Config = toml::from_str(&saved).unwrap();
+        let rule = reparsed.rules.get("pii.fin.credit_card.keyword").unwrap();
+
+        assert!(!saved.contains("enabled"));
+        assert!(rule.enabled);
+        assert!(!rule.enabled_is_set);
+    }
+
+    #[test]
+    fn serialize_preserves_explicit_rule_enabled_true() {
+        let config: Config = toml::from_str(
+            r#"
+[rules."pii.fin.credit_card.keyword"]
+enabled = true
+base_score = 85
+"#,
+        )
+        .unwrap();
+
+        let saved = toml::to_string(&config).unwrap();
+        let reparsed: Config = toml::from_str(&saved).unwrap();
+        let rule = reparsed.rules.get("pii.fin.credit_card.keyword").unwrap();
+
+        assert!(saved.contains("enabled = true"));
+        assert!(rule.enabled);
+        assert!(rule.enabled_is_set);
     }
 
     #[test]

--- a/crates/veil-config/src/config.rs
+++ b/crates/veil-config/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -115,9 +116,14 @@ impl Config {
             self.core.rules_dir = Some(val);
         }
 
-        // Merge Rules (Override/Insert)
+        // Merge Rules (field-wise override/insert)
         for (id, rule) in other.rules {
-            self.rules.insert(id, rule);
+            match self.rules.entry(id) {
+                Entry::Occupied(mut entry) => entry.get_mut().merge(rule),
+                Entry::Vacant(entry) => {
+                    entry.insert(rule);
+                }
+            }
         }
 
         // Merge Masking (Simple override for now as fields are not Option)
@@ -177,10 +183,12 @@ fn default_placeholder() -> String {
     "<REDACTED>".to_string()
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone)]
 pub struct RuleConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
+    #[serde(skip)]
+    pub enabled_is_set: bool,
     pub severity: Option<String>,
     pub pattern: Option<String>,
     pub score: Option<u8>,
@@ -198,6 +206,7 @@ impl Default for RuleConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            enabled_is_set: false,
             severity: None,
             pattern: None,
             score: None,
@@ -209,6 +218,90 @@ impl Default for RuleConfig {
             validator: None,
             description: None,
             placeholder: None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RuleConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawRuleConfig {
+            enabled: Option<bool>,
+            severity: Option<String>,
+            pattern: Option<String>,
+            score: Option<u8>,
+            category: Option<String>,
+            tags: Option<Vec<String>>,
+            base_score: Option<u32>,
+            context_lines_before: Option<u8>,
+            context_lines_after: Option<u8>,
+            validator: Option<String>,
+            description: Option<String>,
+            placeholder: Option<String>,
+        }
+
+        let raw = RawRuleConfig::deserialize(deserializer)?;
+        let enabled_is_set = raw.enabled.is_some();
+
+        Ok(Self {
+            enabled: raw.enabled.unwrap_or(true),
+            enabled_is_set,
+            severity: raw.severity,
+            pattern: raw.pattern,
+            score: raw.score,
+            category: raw.category,
+            tags: raw.tags,
+            base_score: raw.base_score,
+            context_lines_before: raw.context_lines_before,
+            context_lines_after: raw.context_lines_after,
+            validator: raw.validator,
+            description: raw.description,
+            placeholder: raw.placeholder,
+        })
+    }
+}
+
+impl RuleConfig {
+    fn merge(&mut self, other: RuleConfig) {
+        if other.enabled_is_set {
+            self.enabled = other.enabled;
+            self.enabled_is_set = true;
+        }
+        if other.severity.is_some() {
+            self.severity = other.severity;
+        }
+        if other.pattern.is_some() {
+            self.pattern = other.pattern;
+        }
+        if other.score.is_some() {
+            self.score = other.score;
+        }
+        if other.category.is_some() {
+            self.category = other.category;
+        }
+        if other.tags.is_some() {
+            self.tags = other.tags;
+        }
+        if other.base_score.is_some() {
+            self.base_score = other.base_score;
+        }
+        if other.context_lines_before.is_some() {
+            self.context_lines_before = other.context_lines_before;
+        }
+        if other.context_lines_after.is_some() {
+            self.context_lines_after = other.context_lines_after;
+        }
+        if other.validator.is_some() {
+            self.validator = other.validator;
+        }
+        if other.description.is_some() {
+            self.description = other.description;
+        }
+        if other.placeholder.is_some() {
+            self.placeholder = other.placeholder;
         }
     }
 }
@@ -272,5 +365,56 @@ max_findings = 1000
         base.merge(other);
 
         assert_eq!(base.output.max_findings, Some(25));
+    }
+
+    #[test]
+    fn merge_combines_rule_fields_without_erasing_lower_layer_values() {
+        let mut base = Config::default();
+        base.rules.insert(
+            "pii.fin.credit_card.keyword".to_string(),
+            RuleConfig {
+                enabled: false,
+                enabled_is_set: true,
+                base_score: Some(85),
+                ..RuleConfig::default()
+            },
+        );
+        let other: Config = toml::from_str(
+            r#"
+[rules."pii.fin.credit_card.keyword"]
+description = "repo-specific copy"
+"#,
+        )
+        .unwrap();
+
+        base.merge(other);
+        let rule = base.rules.get("pii.fin.credit_card.keyword").unwrap();
+
+        assert!(!rule.enabled);
+        assert_eq!(rule.base_score, Some(85));
+        assert_eq!(rule.description.as_deref(), Some("repo-specific copy"));
+    }
+
+    #[test]
+    fn merge_applies_explicit_rule_enabled_override() {
+        let mut base = Config::default();
+        base.rules.insert(
+            "pii.fin.credit_card.keyword".to_string(),
+            RuleConfig {
+                base_score: Some(85),
+                ..RuleConfig::default()
+            },
+        );
+        let other: Config = toml::from_str(
+            r#"
+[rules."pii.fin.credit_card.keyword"]
+enabled = false
+"#,
+        )
+        .unwrap();
+
+        base.merge(other);
+
+        assert!(!base.rules["pii.fin.credit_card.keyword"].enabled);
     }
 }

--- a/crates/veil-config/src/config.rs
+++ b/crates/veil-config/src/config.rs
@@ -266,15 +266,17 @@ impl<'de> Deserialize<'de> for RuleConfig {
 
 impl RuleConfig {
     fn merge(&mut self, other: RuleConfig) {
+        if other.pattern.is_some() {
+            *self = other;
+            return;
+        }
+
         if other.enabled_is_set {
             self.enabled = other.enabled;
             self.enabled_is_set = true;
         }
         if other.severity.is_some() {
             self.severity = other.severity;
-        }
-        if other.pattern.is_some() {
-            self.pattern = other.pattern;
         }
         if other.score.is_some() {
             self.score = other.score;
@@ -416,5 +418,65 @@ enabled = false
         base.merge(other);
 
         assert!(!base.rules["pii.fin.credit_card.keyword"].enabled);
+    }
+
+    #[test]
+    fn merge_pattern_replacement_reenables_rule_by_default() {
+        let mut base = Config::default();
+        base.rules.insert(
+            "custom.replacement".to_string(),
+            RuleConfig {
+                enabled: false,
+                enabled_is_set: true,
+                validator: Some("luhn".to_string()),
+                ..RuleConfig::default()
+            },
+        );
+        let other: Config = toml::from_str(
+            r#"
+[rules."custom.replacement"]
+pattern = "password"
+"#,
+        )
+        .unwrap();
+
+        base.merge(other);
+        let rule = base.rules.get("custom.replacement").unwrap();
+
+        assert!(rule.enabled);
+        assert_eq!(rule.pattern.as_deref(), Some("password"));
+    }
+
+    #[test]
+    fn merge_pattern_replacement_clears_omitted_lower_layer_fields() {
+        let mut base = Config::default();
+        base.rules.insert(
+            "custom.replacement".to_string(),
+            RuleConfig {
+                validator: Some("luhn".to_string()),
+                placeholder: Some("<CARD>".to_string()),
+                base_score: Some(90),
+                context_lines_before: Some(3),
+                context_lines_after: Some(1),
+                ..RuleConfig::default()
+            },
+        );
+        let other: Config = toml::from_str(
+            r#"
+[rules."custom.replacement"]
+pattern = "password"
+"#,
+        )
+        .unwrap();
+
+        base.merge(other);
+        let rule = base.rules.get("custom.replacement").unwrap();
+
+        assert_eq!(rule.pattern.as_deref(), Some("password"));
+        assert!(rule.validator.is_none());
+        assert!(rule.placeholder.is_none());
+        assert!(rule.base_score.is_none());
+        assert!(rule.context_lines_before.is_none());
+        assert!(rule.context_lines_after.is_none());
     }
 }

--- a/crates/veil-config/src/config.rs
+++ b/crates/veil-config/src/config.rs
@@ -271,9 +271,9 @@ impl RuleConfig {
             return;
         }
 
-        if other.enabled_is_set {
+        if other.enabled_is_set || !other.enabled {
             self.enabled = other.enabled;
-            self.enabled_is_set = true;
+            self.enabled_is_set = other.enabled_is_set || !other.enabled;
         }
         if other.severity.is_some() {
             self.severity = other.severity;
@@ -414,6 +414,30 @@ enabled = false
 "#,
         )
         .unwrap();
+
+        base.merge(other);
+
+        assert!(!base.rules["pii.fin.credit_card.keyword"].enabled);
+    }
+
+    #[test]
+    fn merge_treats_programmatic_enabled_false_as_explicit_disable() {
+        let mut base = Config::default();
+        base.rules.insert(
+            "pii.fin.credit_card.keyword".to_string(),
+            RuleConfig {
+                base_score: Some(85),
+                ..RuleConfig::default()
+            },
+        );
+        let mut other = Config::default();
+        other.rules.insert(
+            "pii.fin.credit_card.keyword".to_string(),
+            RuleConfig {
+                enabled: false,
+                ..RuleConfig::default()
+            },
+        );
 
         base.merge(other);
 

--- a/crates/veil-config/src/config.rs
+++ b/crates/veil-config/src/config.rs
@@ -206,7 +206,7 @@ impl Default for RuleConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            enabled_is_set: false,
+            enabled_is_set: true,
             severity: None,
             pattern: None,
             score: None,
@@ -442,6 +442,32 @@ enabled = false
         base.merge(other);
 
         assert!(!base.rules["pii.fin.credit_card.keyword"].enabled);
+    }
+
+    #[test]
+    fn merge_treats_programmatic_enabled_true_as_explicit_enable() {
+        let mut base = Config::default();
+        base.rules.insert(
+            "pii.fin.credit_card.keyword".to_string(),
+            RuleConfig {
+                enabled: false,
+                enabled_is_set: true,
+                base_score: Some(85),
+                ..RuleConfig::default()
+            },
+        );
+        let mut other = Config::default();
+        other.rules.insert(
+            "pii.fin.credit_card.keyword".to_string(),
+            RuleConfig {
+                enabled: true,
+                ..RuleConfig::default()
+            },
+        );
+
+        base.merge(other);
+
+        assert!(base.rules["pii.fin.credit_card.keyword"].enabled);
     }
 
     #[test]

--- a/crates/veil-config/src/config.rs
+++ b/crates/veil-config/src/config.rs
@@ -103,6 +103,9 @@ impl Config {
         if !other.output.show_snippets {
             self.output.show_snippets = false;
         }
+        if other.output.max_findings != default_max_findings() {
+            self.output.max_findings = other.output.max_findings;
+        }
     }
 }
 
@@ -199,5 +202,27 @@ mod tests {
 
         assert_eq!(config.core.max_file_size, Some(1024));
         assert_eq!(config.core.max_file_count, None);
+    }
+
+    #[test]
+    fn merge_copies_non_default_max_findings() {
+        let mut base = Config::default();
+        let mut other = Config::default();
+        other.output.max_findings = Some(25);
+
+        base.merge(other);
+
+        assert_eq!(base.output.max_findings, Some(25));
+    }
+
+    #[test]
+    fn merge_does_not_let_default_max_findings_override_existing_layer() {
+        let mut base = Config::default();
+        base.output.max_findings = Some(25);
+        let other = Config::default();
+
+        base.merge(other);
+
+        assert_eq!(base.output.max_findings, Some(25));
     }
 }

--- a/crates/veil-config/src/config.rs
+++ b/crates/veil-config/src/config.rs
@@ -160,6 +160,25 @@ pub struct RuleConfig {
     pub placeholder: Option<String>,
 }
 
+impl Default for RuleConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            severity: None,
+            pattern: None,
+            score: None,
+            category: None,
+            tags: None,
+            base_score: None,
+            context_lines_before: None,
+            context_lines_after: None,
+            validator: None,
+            description: None,
+            placeholder: None,
+        }
+    }
+}
+
 fn default_true() -> bool {
     true
 }

--- a/crates/veil-config/src/config.rs
+++ b/crates/veil-config/src/config.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -13,14 +13,15 @@ pub struct Config {
     pub rules: HashMap<String, RuleConfig>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone)]
 pub struct OutputConfig {
     #[serde(default)]
     pub mask_mode: Option<MaskMode>,
     #[serde(default = "default_true")]
     pub show_snippets: bool,
-    #[serde(default = "default_max_findings")]
     pub max_findings: Option<usize>,
+    #[serde(skip)]
+    pub max_findings_is_set: bool,
 }
 
 impl Default for OutputConfig {
@@ -29,7 +30,36 @@ impl Default for OutputConfig {
             mask_mode: None,
             show_snippets: true,
             max_findings: Some(1000),
+            max_findings_is_set: false,
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for OutputConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawOutputConfig {
+            #[serde(default)]
+            mask_mode: Option<MaskMode>,
+            #[serde(default = "default_true")]
+            show_snippets: bool,
+            #[serde(default)]
+            max_findings: Option<Option<usize>>,
+        }
+
+        let raw = RawOutputConfig::deserialize(deserializer)?;
+        let max_findings_is_set = raw.max_findings.is_some();
+        let max_findings = raw.max_findings.unwrap_or_else(default_max_findings);
+
+        Ok(Self {
+            mask_mode: raw.mask_mode,
+            show_snippets: raw.show_snippets,
+            max_findings,
+            max_findings_is_set,
+        })
     }
 }
 
@@ -103,8 +133,9 @@ impl Config {
         if !other.output.show_snippets {
             self.output.show_snippets = false;
         }
-        if other.output.max_findings != default_max_findings() {
+        if other.output.max_findings_is_set || other.output.max_findings != default_max_findings() {
             self.output.max_findings = other.output.max_findings;
+            self.output.max_findings_is_set = other.output.max_findings_is_set;
         }
     }
 }
@@ -213,6 +244,23 @@ mod tests {
         base.merge(other);
 
         assert_eq!(base.output.max_findings, Some(25));
+    }
+
+    #[test]
+    fn merge_copies_explicit_default_max_findings() {
+        let mut base = Config::default();
+        base.output.max_findings = Some(25);
+        let other: Config = toml::from_str(
+            r#"
+[output]
+max_findings = 1000
+"#,
+        )
+        .unwrap();
+
+        base.merge(other);
+
+        assert_eq!(base.output.max_findings, Some(1000));
     }
 
     #[test]

--- a/crates/veil-config/src/lib.rs
+++ b/crates/veil-config/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod config;
 pub mod loader;
+pub mod presets;
 pub mod validate;
 
 pub use config::{Config, MaskMode, OutputConfig, RuleConfig};
 pub use loader::load_config;
+pub use presets::{apply_builtin_preset_as_base, builtin_preset_config, BUILTIN_PRESET_IDS};

--- a/crates/veil-config/src/presets.rs
+++ b/crates/veil-config/src/presets.rs
@@ -75,6 +75,7 @@ fn parse_preset_config(preset_id: &str, source: &str) -> Result<Config> {
 
         let rule_config = RuleConfig {
             enabled: rule_override.enabled.unwrap_or(true),
+            enabled_is_set: rule_override.enabled.is_some(),
             base_score: rule_override.base_score,
             ..RuleConfig::default()
         };
@@ -139,6 +140,7 @@ severity = "high"
             "pii.fin.credit_card.keyword".to_string(),
             RuleConfig {
                 enabled: false,
+                enabled_is_set: true,
                 base_score: Some(99),
                 ..RuleConfig::default()
             },
@@ -159,5 +161,22 @@ severity = "high"
         let merged = apply_builtin_preset_as_base(config, "fintech-jp").unwrap();
 
         assert_eq!(merged.output.max_findings, Some(25));
+    }
+
+    #[test]
+    fn apply_builtin_preset_as_base_preserves_rule_fields_for_partial_override() {
+        let config: Config = toml::from_str(
+            r#"
+[rules."pii.fin.credit_card.keyword"]
+description = "repo-specific copy"
+"#,
+        )
+        .unwrap();
+
+        let merged = apply_builtin_preset_as_base(config, "fintech-jp").unwrap();
+        let rule = merged.rules.get("pii.fin.credit_card.keyword").unwrap();
+
+        assert_eq!(rule.base_score, Some(85));
+        assert_eq!(rule.description.as_deref(), Some("repo-specific copy"));
     }
 }

--- a/crates/veil-config/src/presets.rs
+++ b/crates/veil-config/src/presets.rs
@@ -1,0 +1,153 @@
+use crate::config::{Config, RuleConfig};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+pub const BUILTIN_PRESET_IDS: &[&str] = &[
+    "standard-jp",
+    "fintech-jp",
+    "gov-jp",
+    "logs-jp",
+    "si-vendor-jp",
+];
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PresetFile {
+    #[serde(default)]
+    rules: HashMap<String, PresetRuleOverride>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PresetRuleOverride {
+    enabled: Option<bool>,
+    base_score: Option<u32>,
+}
+
+pub fn builtin_preset_config(preset_id: &str) -> Result<Config> {
+    let source = builtin_preset_source(preset_id)?;
+    parse_preset_config(preset_id, source)
+}
+
+pub fn apply_builtin_preset_as_base(config: Config, preset_id: &str) -> Result<Config> {
+    let mut preset_config = builtin_preset_config(preset_id)?;
+    preset_config.merge(config);
+    Ok(preset_config)
+}
+
+fn builtin_preset_source(preset_id: &str) -> Result<&'static str> {
+    match preset_id {
+        "standard-jp" => Ok(include_str!("../../veil/presets/standard-jp.toml")),
+        "fintech-jp" => Ok(include_str!("../../veil/presets/fintech-jp.toml")),
+        "gov-jp" => Ok(include_str!("../../veil/presets/gov-jp.toml")),
+        "logs-jp" => Ok(include_str!("../../veil/presets/logs-jp.toml")),
+        "si-vendor-jp" => Ok(include_str!("../../veil/presets/si-vendor-jp.toml")),
+        _ => bail!(
+            "Unknown preset '{}'. Built-in presets: {}",
+            preset_id,
+            BUILTIN_PRESET_IDS.join(", ")
+        ),
+    }
+}
+
+fn parse_preset_config(preset_id: &str, source: &str) -> Result<Config> {
+    let preset: PresetFile = toml::from_str(source)
+        .with_context(|| format!("Invalid preset TOML for '{}'", preset_id))?;
+
+    if preset.rules.is_empty() {
+        bail!(
+            "Preset '{}' must contain at least one rule override",
+            preset_id
+        );
+    }
+
+    let mut config = Config::default();
+    config.core.include.clear();
+    for (rule_id, rule_override) in preset.rules {
+        if rule_override.enabled.is_none() && rule_override.base_score.is_none() {
+            bail!(
+                "Preset '{}' rule '{}' must set enabled and/or base_score",
+                preset_id,
+                rule_id
+            );
+        }
+
+        let rule_config = RuleConfig {
+            enabled: rule_override.enabled.unwrap_or(true),
+            base_score: rule_override.base_score,
+            ..RuleConfig::default()
+        };
+        config.rules.insert(rule_id, rule_config);
+    }
+
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_builtin_presets_parse_to_rule_overrides() {
+        for preset_id in BUILTIN_PRESET_IDS {
+            let config = builtin_preset_config(preset_id).unwrap();
+            assert!(
+                !config.rules.is_empty(),
+                "preset '{}' should define rule overrides",
+                preset_id
+            );
+            for rule in config.rules.values() {
+                assert!(rule.severity.is_none());
+                assert!(rule.pattern.is_none());
+                assert!(rule.score.is_none());
+                assert!(rule.category.is_none());
+                assert!(rule.tags.is_none());
+                assert!(rule.validator.is_none());
+            }
+            assert!(config.core.include.is_empty());
+            assert!(config.core.ignore.is_empty());
+            assert!(config.core.rules_dir.is_none());
+        }
+    }
+
+    #[test]
+    fn unknown_builtin_preset_errors() {
+        let err = builtin_preset_config("minimal-ci").unwrap_err();
+        assert!(err.to_string().contains("Unknown preset 'minimal-ci'"));
+    }
+
+    #[test]
+    fn preset_rejects_fields_outside_enabled_and_base_score() {
+        let err = parse_preset_config(
+            "bad",
+            r#"
+[rules."pii.jp.mynumber.keyword"]
+enabled = true
+severity = "high"
+"#,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("Invalid preset TOML"));
+    }
+
+    #[test]
+    fn apply_builtin_preset_as_base_lets_config_override_rules() {
+        let mut config = Config::default();
+        config.rules.insert(
+            "pii.fin.credit_card.keyword".to_string(),
+            RuleConfig {
+                enabled: false,
+                base_score: Some(99),
+                ..RuleConfig::default()
+            },
+        );
+
+        let merged = apply_builtin_preset_as_base(config, "fintech-jp").unwrap();
+        let rule = merged.rules.get("pii.fin.credit_card.keyword").unwrap();
+
+        assert!(!rule.enabled);
+        assert_eq!(rule.base_score, Some(99));
+    }
+}

--- a/crates/veil-config/src/presets.rs
+++ b/crates/veil-config/src/presets.rs
@@ -150,4 +150,14 @@ severity = "high"
         assert!(!rule.enabled);
         assert_eq!(rule.base_score, Some(99));
     }
+
+    #[test]
+    fn apply_builtin_preset_as_base_preserves_max_findings_override() {
+        let mut config = Config::default();
+        config.output.max_findings = Some(25);
+
+        let merged = apply_builtin_preset_as_base(config, "fintech-jp").unwrap();
+
+        assert_eq!(merged.output.max_findings, Some(25));
+    }
 }

--- a/crates/veil-config/src/presets.rs
+++ b/crates/veil-config/src/presets.rs
@@ -38,11 +38,11 @@ pub fn apply_builtin_preset_as_base(config: Config, preset_id: &str) -> Result<C
 
 fn builtin_preset_source(preset_id: &str) -> Result<&'static str> {
     match preset_id {
-        "standard-jp" => Ok(include_str!("../../veil/presets/standard-jp.toml")),
-        "fintech-jp" => Ok(include_str!("../../veil/presets/fintech-jp.toml")),
-        "gov-jp" => Ok(include_str!("../../veil/presets/gov-jp.toml")),
-        "logs-jp" => Ok(include_str!("../../veil/presets/logs-jp.toml")),
-        "si-vendor-jp" => Ok(include_str!("../../veil/presets/si-vendor-jp.toml")),
+        "standard-jp" => Ok(include_str!("../presets/standard-jp.toml")),
+        "fintech-jp" => Ok(include_str!("../presets/fintech-jp.toml")),
+        "gov-jp" => Ok(include_str!("../presets/gov-jp.toml")),
+        "logs-jp" => Ok(include_str!("../presets/logs-jp.toml")),
+        "si-vendor-jp" => Ok(include_str!("../presets/si-vendor-jp.toml")),
         _ => bail!(
             "Unknown preset '{}'. Built-in presets: {}",
             preset_id,

--- a/crates/veil-config/src/validate.rs
+++ b/crates/veil-config/src/validate.rs
@@ -94,6 +94,7 @@ mod tests {
 
         let rule = crate::config::RuleConfig {
             enabled: true,
+            enabled_is_set: true,
             severity: Some("high".to_string()),
             pattern: Some(long_pattern),
             score: Some(10),

--- a/crates/veil-core/src/rules/builtin.rs
+++ b/crates/veil-core/src/rules/builtin.rs
@@ -228,6 +228,7 @@ mod tests {
             "custom.invalid_validator".to_string(),
             RuleConfig {
                 enabled: true,
+                enabled_is_set: true,
                 severity: None,
                 pattern: Some("SECRET".to_string()),
                 score: None,

--- a/crates/veil-core/src/rules/builtin.rs
+++ b/crates/veil-core/src/rules/builtin.rs
@@ -178,6 +178,9 @@ pub fn try_get_all_rules(config: &Config, extra_rules: Vec<Rule>) -> Result<Vec<
                 if let Some(score) = rule_conf.score {
                     rule.score = score as u32;
                 }
+                if let Some(base_score) = rule_conf.base_score {
+                    rule.base_score = Some(base_score);
+                }
                 if let Some(cat) = &rule_conf.category {
                     rule.category = cat.clone();
                 }
@@ -255,5 +258,53 @@ mod tests {
         let rules = get_all_rules(&rule_config_with_unknown_validator(), vec![]);
 
         assert!(!rules.is_empty());
+    }
+
+    #[test]
+    fn builtin_preset_base_score_override_is_applied() {
+        let config = veil_config::builtin_preset_config("fintech-jp").unwrap();
+        let rules = try_get_all_rules(&config, vec![]).unwrap();
+        let card = rules
+            .iter()
+            .find(|rule| rule.id == "pii.fin.credit_card.keyword")
+            .unwrap();
+
+        assert_eq!(card.base_score, Some(85));
+    }
+
+    #[test]
+    fn builtin_preset_enabled_override_filters_rule() {
+        let mut config = veil_config::builtin_preset_config("fintech-jp").unwrap();
+        config
+            .rules
+            .get_mut("pii.fin.credit_card.keyword")
+            .unwrap()
+            .enabled = false;
+
+        let rules = try_get_all_rules(&config, vec![]).unwrap();
+
+        assert!(!rules
+            .iter()
+            .any(|rule| rule.id == "pii.fin.credit_card.keyword"));
+    }
+
+    #[test]
+    fn logs_preset_overrides_loaded_log_rule_pack() {
+        let mut config = veil_config::builtin_preset_config("logs-jp").unwrap();
+        let rules_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("veil")
+            .join("rules")
+            .join("log");
+        config.core.rules_dir = Some(rules_dir.to_string_lossy().to_string());
+
+        let rules = try_get_all_rules(&config, vec![]).unwrap();
+        let log_card = rules
+            .iter()
+            .find(|rule| rule.id == "log.pii.credit_card")
+            .unwrap();
+
+        assert_eq!(log_card.base_score, Some(88));
     }
 }

--- a/crates/veil-pro/src/api.rs
+++ b/crates/veil-pro/src/api.rs
@@ -1133,6 +1133,7 @@ mod tests {
             "custom.invalid_validator".to_string(),
             veil_config::RuleConfig {
                 enabled: true,
+                enabled_is_set: true,
                 severity: None,
                 pattern: Some("SECRET".to_string()),
                 score: None,

--- a/crates/veil/presets/fintech-jp.toml
+++ b/crates/veil/presets/fintech-jp.toml
@@ -1,0 +1,11 @@
+[rules."pii.jp.mynumber.unlabeled"]
+enabled = true
+base_score = 72
+
+[rules."pii.fin.credit_card.keyword"]
+enabled = true
+base_score = 85
+
+[rules."pii.fin.bank_account.keyword"]
+enabled = true
+base_score = 80

--- a/crates/veil/presets/gov-jp.toml
+++ b/crates/veil/presets/gov-jp.toml
@@ -1,0 +1,11 @@
+[rules."pii.jp.mynumber.keyword"]
+enabled = true
+base_score = 92
+
+[rules."pii.jp.address.prefecture_heuristic"]
+enabled = true
+base_score = 55
+
+[rules."pii.person.name.keyword"]
+enabled = true
+base_score = 45

--- a/crates/veil/presets/logs-jp.toml
+++ b/crates/veil/presets/logs-jp.toml
@@ -1,0 +1,15 @@
+[rules."log.pii.jp.mynumber.keyword"]
+enabled = true
+base_score = 90
+
+[rules."log.pii.credit_card"]
+enabled = true
+base_score = 88
+
+[rules."log.pii.jp.phone.keyword"]
+enabled = true
+base_score = 70
+
+[rules."log.pii.jp.postal.keyword"]
+enabled = true
+base_score = 75

--- a/crates/veil/presets/si-vendor-jp.toml
+++ b/crates/veil/presets/si-vendor-jp.toml
@@ -1,0 +1,7 @@
+[rules."pii.jp.mynumber.keyword"]
+enabled = true
+base_score = 92
+
+[rules."pii.jp.address.prefecture_heuristic"]
+enabled = true
+base_score = 55

--- a/crates/veil/presets/standard-jp.toml
+++ b/crates/veil/presets/standard-jp.toml
@@ -1,0 +1,7 @@
+[rules."pii.jp.mynumber.keyword"]
+enabled = true
+base_score = 92
+
+[rules."pii.person.name.keyword"]
+enabled = true
+base_score = 45

--- a/docs/pr/PR-103-jp-preset-overrides.md
+++ b/docs/pr/PR-103-jp-preset-overrides.md
@@ -1,0 +1,52 @@
+# PR-103: JP preset override resolver
+
+## Why
+- JP PII validators become operational only when teams can choose a scenario-oriented preset.
+- The preset data contract should be narrow and deterministic before exposing CLI UX.
+- Keeping presets to rule overrides makes review, rollback, and future expansion easier.
+
+## Summary
+- Add built-in JP preset TOML files.
+- Add a preset resolver in `veil-config`.
+- Apply preset rule overrides as a base config layer while preserving repo override behavior.
+
+## Changes
+- Add `standard-jp`, `fintech-jp`, `gov-jp`, `logs-jp`, and `si-vendor-jp` preset TOML files.
+- Limit preset TOML to `enabled` and `base_score`.
+- Reject unknown fields in preset TOML.
+- Add `builtin_preset_config` and `apply_builtin_preset_as_base`.
+- Apply `RuleConfig.base_score` to resolved built-in and rule-pack rules.
+- Cover unknown preset IDs, forbidden fields, enabled filtering, base score overrides, and `logs-jp` with the log rule pack.
+
+## Non-goals
+- No `veil scan --preset` CLI UX.
+- No `veil init --preset` CLI UX.
+- No preset severity field; score remains the source of truth.
+- No preset-controlled `rules_dir`, output settings, or core include/ignore settings.
+
+## Impact / Scope
+- CLI: no user-facing preset command in this PR.
+- CI: adds focused preset resolver tests.
+- Docs: SOT only.
+- Rules: preset files adjust rule enablement and base scores only.
+- Tests: config and core resolver behavior.
+
+## Verification
+
+### Commands
+```bash
+cargo fmt --all --check
+cargo test -p veil-config presets
+cargo test -p veil-config
+cargo test -p veil-core rules::builtin::tests
+cargo test -p veil-core
+python scripts/check_generated_schemas.py
+cargo test --workspace
+```
+
+### Evidence
+- Local validation passed before opening the draft PR.
+- This PR is stacked on PR #102.
+
+## Rollback
+- Revert this PR to remove preset TOML files and resolver behavior while keeping validator support from PR #102.


### PR DESCRIPTION
## Summary

- Add built-in JP preset TOML files for `standard-jp`, `fintech-jp`, `gov-jp`, `logs-jp`, and `si-vendor-jp`.
- Keep preset rule overrides limited to `enabled` and `base_score`; new preset TOML does not use `severity`, `score`, `pattern`, `rules_dir`, or output/core settings.
- Add `veil-config` preset loading APIs that turn a built-in preset into a base-layer `Config`.
- Apply `RuleConfig.base_score` to existing built-in/rule-pack rules in the rule resolver.
- Add tests for preset parsing, unknown preset errors, forbidden preset fields, repo override precedence, built-in base_score application, enabled filtering, and `logs-jp` with the log RulePack loaded.

This is stacked on PR #102 and intentionally does not include `veil scan --preset` or `veil init --preset` CLI UX.

## Validation

- `cargo fmt --all --check`
- `cargo test -p veil-config presets`
- `cargo test -p veil-config`
- `cargo test -p veil-core rules::builtin::tests`
- `cargo test -p veil-core`
- `python scripts/check_generated_schemas.py`
- `cargo test --workspace`

### SOT
- docs/pr/PR-103-jp-preset-overrides.md