### PR TITLE
Add JP preset CLI UX

### DIFF
--- a/crates/veil-cli/src/cli.rs
+++ b/crates/veil-cli/src/cli.rs
@@ -30,6 +30,9 @@ pub enum Commands {
         /// Paths to scan
         #[arg(default_value = ".")]
         paths: Vec<PathBuf>,
+        /// Apply a built-in preset as the base config layer
+        #[arg(long, value_name = "ID")]
+        preset: Option<String>,
         /// Output format (text, json, html, markdown, table)
         ///
         /// - text:     Standard colorful terminal output (default)
@@ -109,6 +112,9 @@ pub enum Commands {
         /// Initialize with a specific profile (e.g. "Logs") without wizard
         #[arg(long)]
         profile: Option<String>,
+        /// Apply a built-in preset to the generated config
+        #[arg(long, value_name = "ID")]
+        preset: Option<String>,
         /// Pin the GitHub Actions workflow to a specific version tag.
         /// - "auto" (default): Use current version (if stable) or display warning (if prerelease)
         /// - "none": Do not pin version (use latest from main/master)
@@ -282,8 +288,12 @@ pub enum ConfigCommand {
         #[arg(long)]
         config_path: Option<PathBuf>,
     },
-    /// Dump configuration (org/user/repo/effective)
+    /// Dump configuration (preset/org/user/repo/effective)
     Dump {
+        /// Apply a built-in preset before other config layers
+        #[arg(long, value_name = "ID")]
+        preset: Option<String>,
+
         /// Which layer to dump (default: effective)
         #[arg(long, value_enum)]
         layer: Option<ConfigLayer>,
@@ -296,6 +306,7 @@ pub enum ConfigCommand {
 
 #[derive(clap::ValueEnum, Copy, Clone, Debug)]
 pub enum ConfigLayer {
+    Preset,
     Org,
     User,
     Repo,

--- a/crates/veil-cli/src/cli.rs
+++ b/crates/veil-cli/src/cli.rs
@@ -304,7 +304,7 @@ pub enum ConfigCommand {
     },
 }
 
-#[derive(clap::ValueEnum, Copy, Clone, Debug)]
+#[derive(clap::ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ConfigLayer {
     Preset,
     Org,

--- a/crates/veil-cli/src/commands/config.rs
+++ b/crates/veil-cli/src/commands/config.rs
@@ -109,14 +109,26 @@ pub fn dump(
     use crate::config_loader::load_config_layers_with_preset;
     use veil_config::Config;
 
-    let layers = load_config_layers_with_preset(explicit_path, preset_id)?;
+    let selected_layer = layer.unwrap_or(ConfigLayer::Effective);
+    let preset_only = if selected_layer == ConfigLayer::Preset {
+        preset_id
+            .map(veil_config::builtin_preset_config)
+            .transpose()?
+    } else {
+        None
+    };
+    let layers = if selected_layer == ConfigLayer::Preset {
+        None
+    } else {
+        Some(load_config_layers_with_preset(explicit_path, preset_id)?)
+    };
 
-    let selected: Option<&Config> = match layer.unwrap_or(ConfigLayer::Effective) {
-        ConfigLayer::Preset => layers.preset.as_ref(),
-        ConfigLayer::Org => layers.org.as_ref(),
-        ConfigLayer::User => layers.user.as_ref(),
-        ConfigLayer::Repo => layers.repo.as_ref(),
-        ConfigLayer::Effective => Some(&layers.effective),
+    let selected: Option<&Config> = match selected_layer {
+        ConfigLayer::Preset => preset_only.as_ref(),
+        ConfigLayer::Org => layers.as_ref().and_then(|layers| layers.org.as_ref()),
+        ConfigLayer::User => layers.as_ref().and_then(|layers| layers.user.as_ref()),
+        ConfigLayer::Repo => layers.as_ref().and_then(|layers| layers.repo.as_ref()),
+        ConfigLayer::Effective => layers.as_ref().map(|layers| &layers.effective),
     };
 
     let Some(config) = selected else {

--- a/crates/veil-cli/src/commands/config.rs
+++ b/crates/veil-cli/src/commands/config.rs
@@ -101,16 +101,18 @@ fn check_rule_safety(rule: &Rule) -> Result<(), SafetyIssue> {
 
 pub fn dump(
     explicit_path: Option<&PathBuf>,
+    preset_id: Option<&str>,
     layer: Option<crate::cli::ConfigLayer>,
     format: Option<crate::cli::ConfigFormat>,
 ) -> Result<()> {
     use crate::cli::{ConfigFormat, ConfigLayer};
-    use crate::config_loader::load_config_layers;
+    use crate::config_loader::load_config_layers_with_preset;
     use veil_config::Config;
 
-    let layers = load_config_layers(explicit_path)?;
+    let layers = load_config_layers_with_preset(explicit_path, preset_id)?;
 
     let selected: Option<&Config> = match layer.unwrap_or(ConfigLayer::Effective) {
+        ConfigLayer::Preset => layers.preset.as_ref(),
         ConfigLayer::Org => layers.org.as_ref(),
         ConfigLayer::User => layers.user.as_ref(),
         ConfigLayer::Repo => layers.repo.as_ref(),

--- a/crates/veil-cli/src/commands/config.rs
+++ b/crates/veil-cli/src/commands/config.rs
@@ -106,7 +106,7 @@ pub fn dump(
     format: Option<crate::cli::ConfigFormat>,
 ) -> Result<()> {
     use crate::cli::{ConfigFormat, ConfigLayer};
-    use crate::config_loader::load_config_layers_with_preset;
+    use crate::config_loader::load_config_layers_with_preset_for_dump;
     use veil_config::Config;
 
     let selected_layer = layer.unwrap_or(ConfigLayer::Effective);
@@ -120,7 +120,10 @@ pub fn dump(
     let layers = if selected_layer == ConfigLayer::Preset {
         None
     } else {
-        Some(load_config_layers_with_preset(explicit_path, preset_id)?)
+        Some(load_config_layers_with_preset_for_dump(
+            explicit_path,
+            preset_id,
+        )?)
     };
 
     let selected: Option<&Config> = match selected_layer {

--- a/crates/veil-cli/src/commands/init.rs
+++ b/crates/veil-cli/src/commands/init.rs
@@ -3,7 +3,7 @@ use colored::*;
 use rust_embed::RustEmbed;
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use veil_config::config::{Config, CoreConfig, MaskingConfig};
 
 #[derive(RustEmbed)]
@@ -273,16 +273,16 @@ pub fn init(
     }
     let toml_str = toml::to_string_pretty(&config)?;
 
+    let path = answers.target_path.as_deref().unwrap_or(path);
     let should_init_log_pack =
         answers.profile == Profile::Logs || preset.as_deref() == Some("logs-jp");
-    let log_pack_rules_dir = Path::new("rules/log");
+    let log_pack_rules_dir = log_pack_rules_dir_for_config(path);
     let log_pack_created_any = if should_init_log_pack {
-        Some(ensure_log_pack_for_init(log_pack_rules_dir)?)
+        Some(ensure_log_pack_for_init(&log_pack_rules_dir)?)
     } else {
         None
     };
 
-    let path = answers.target_path.as_deref().unwrap_or(path);
     fs::write(path, toml_str)?;
 
     // Post-generation for Logs profile or logs preset
@@ -290,11 +290,19 @@ pub fn init(
         if created_any {
             println!(
                 "{}",
-                "Log RulePack initialized at rules/log (wired via core.rules_dir).".green()
+                format!(
+                    "Log RulePack initialized at {} (wired via core.rules_dir).",
+                    log_pack_rules_dir.display()
+                )
+                .green()
             );
             println!(
                 "{}",
-                "Tip: In rules/log/00_manifest.toml, uncomment the `ext = \"aggressive\"` line to enable aggressive rules.".bright_black()
+                format!(
+                    "Tip: In {}/00_manifest.toml, uncomment the `ext = \"aggressive\"` line to enable aggressive rules.",
+                    log_pack_rules_dir.display()
+                )
+                .bright_black()
             );
         } else {
             println!(
@@ -319,6 +327,14 @@ pub fn init(
     }
 
     Ok(())
+}
+
+fn log_pack_rules_dir_for_config(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(|parent| parent.join("rules/log"))
+        .unwrap_or_else(|| PathBuf::from("rules/log"))
 }
 
 fn ensure_log_pack_for_init(rules_dir: &Path) -> Result<bool> {
@@ -362,9 +378,10 @@ fn validate_log_pack_for_init(rules_dir: &Path) -> Result<()> {
 
     if !missing_ids.is_empty() {
         anyhow::bail!(
-            "Existing log RulePack at {} is missing required logs-jp rules: {}. Repair or remove rules/log, then rerun `veil init --preset logs-jp`.",
+            "Existing log RulePack at {} is missing required logs-jp rules: {}. Repair or remove {}, then rerun `veil init --preset logs-jp`.",
             rules_dir.display(),
-            missing_ids.join(", ")
+            missing_ids.join(", "),
+            rules_dir.display()
         );
     }
 
@@ -691,5 +708,17 @@ mod tests {
         let config = build_config(&answers);
         assert_eq!(config.core.fail_on_score, Some(80)); // App default
         assert!(!config.core.ignore.contains(&"tests".to_string()));
+    }
+
+    #[test]
+    fn log_pack_rules_dir_follows_config_parent() {
+        assert_eq!(
+            log_pack_rules_dir_for_config(Path::new("veil.toml")),
+            PathBuf::from("rules/log")
+        );
+        assert_eq!(
+            log_pack_rules_dir_for_config(Path::new("configs/veil.logs.toml")),
+            PathBuf::from("configs/rules/log")
+        );
     }
 }

--- a/crates/veil-cli/src/commands/init.rs
+++ b/crates/veil-cli/src/commands/init.rs
@@ -174,6 +174,7 @@ pub fn init(
     non_interactive: bool,
     ci_provider: Option<String>,
     profile_override: Option<String>,
+    preset: Option<String>,
     pin_tag: String,
 ) -> Result<()> {
     if let Some(provider) = ci_provider {
@@ -214,6 +215,8 @@ pub fn init(
                 "application" | "app" => Profile::Application,
                 _ => Profile::Application,
             }
+        } else if preset.as_deref() == Some("logs-jp") {
+            Profile::Logs
         } else {
             Profile::Application
         };
@@ -253,7 +256,18 @@ pub fn init(
         }
     };
 
-    let config = build_config(&answers);
+    let mut config = build_config(&answers);
+    if let Some(preset_id) = preset.as_deref() {
+        config = veil_config::apply_builtin_preset_as_base(config, preset_id)?;
+        println!(
+            "{}",
+            format!(
+                "Applied preset '{}' as the base config layer; generated config can override it.",
+                preset_id
+            )
+            .dimmed()
+        );
+    }
     let toml_str = toml::to_string_pretty(&config)?;
 
     let path = answers.target_path.as_deref().unwrap_or(path);

--- a/crates/veil-cli/src/commands/init.rs
+++ b/crates/veil-cli/src/commands/init.rs
@@ -178,6 +178,24 @@ pub fn init(
     pin_tag: String,
 ) -> Result<()> {
     if let Some(provider) = ci_provider {
+        if preset.is_some() {
+            anyhow::bail!(
+                "--preset cannot be combined with --ci. Run `veil init --preset <preset>` first, then `veil init --ci {}`.",
+                provider
+            );
+        }
+        if profile_override.is_some() {
+            anyhow::bail!(
+                "--profile cannot be combined with --ci. Run `veil init --profile <profile>` first, then `veil init --ci {}`.",
+                provider
+            );
+        }
+        if wizard {
+            anyhow::bail!(
+                "--wizard cannot be combined with --ci. Run `veil init --wizard` first, then `veil init --ci {}`.",
+                provider
+            );
+        }
         return generate_ci_template(&provider, &pin_tag);
     }
 

--- a/crates/veil-cli/src/commands/init.rs
+++ b/crates/veil-cli/src/commands/init.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored::*;
 use rust_embed::RustEmbed;
 use std::collections::HashMap;
@@ -276,6 +276,52 @@ pub fn init(
     let path = answers.target_path.as_deref().unwrap_or(path);
     fs::write(path, toml_str)?;
 
+    // Post-generation for Logs profile or logs preset
+    if answers.profile == Profile::Logs || preset.as_deref() == Some("logs-jp") {
+        let rules_dir = Path::new("rules/log");
+        if !rules_dir.exists() {
+            fs::create_dir_all(rules_dir)?;
+            println!(
+                "{}",
+                format!("Created directory {}", rules_dir.display()).green()
+            );
+        }
+
+        let mut created_any = false;
+        for file in LogPackAssets::iter() {
+            let file_path = rules_dir.join(file.as_ref());
+            if !file_path.exists() {
+                if let Some(content) = LogPackAssets::get(file.as_ref()) {
+                    fs::write(&file_path, content.data.as_ref())?;
+                    println!("  - Created {}", file.as_ref());
+                    created_any = true;
+                }
+            }
+        }
+
+        validate_log_pack_for_init(rules_dir)?;
+
+        if created_any {
+            println!(
+                "{}",
+                "Log RulePack initialized at rules/log (wired via core.rules_dir).".green()
+            );
+            println!(
+                "{}",
+                "Tip: In rules/log/00_manifest.toml, uncomment the `ext = \"aggressive\"` line to enable aggressive rules.".bright_black()
+            );
+        } else {
+            println!(
+                "{}",
+                format!(
+                    "Directory {} already contains a usable log RulePack.",
+                    rules_dir.display()
+                )
+                .yellow()
+            );
+        }
+    }
+
     println!(
         "{}",
         format!("Successfully created {}", path.display())
@@ -286,46 +332,30 @@ pub fn init(
         println!("Policy: Fail on score >= {}", score);
     }
 
-    // Post-generation for Logs profile or logs preset
-    if answers.profile == Profile::Logs || preset.as_deref() == Some("logs-jp") {
-        let rules_dir = Path::new("rules/log");
-        if !rules_dir.exists() {
-            fs::create_dir_all(rules_dir)?;
-            println!(
-                "{}",
-                format!("Created directory {}", rules_dir.display()).green()
-            );
-            let mut created_any = false;
-            for file in LogPackAssets::iter() {
-                let file_path = rules_dir.join(file.as_ref());
-                if let Some(content) = LogPackAssets::get(file.as_ref()) {
-                    fs::write(&file_path, content.data.as_ref())?;
-                    println!("  - Created {}", file.as_ref());
-                    created_any = true;
-                }
-            }
+    Ok(())
+}
 
-            if created_any {
-                println!(
-                    "{}",
-                    "Log RulePack initialized at rules/log (wired via core.rules_dir).".green()
-                );
-                println!(
-                    "{}",
-                    "Tip: In rules/log/00_manifest.toml, uncomment the `ext = \"aggressive\"` line to enable aggressive rules.".bright_black()
-                );
-            }
-        } else {
-            println!(
-                "{}",
-                format!(
-                    "Directory {} already exists, skipping rule pack generation.",
-                    rules_dir.display()
-                )
-                .yellow()
-            );
-        }
+fn validate_log_pack_for_init(rules_dir: &Path) -> Result<()> {
+    let rules = veil_core::rules::pack::load_rule_pack(rules_dir).with_context(|| {
+        format!(
+            "Existing log RulePack at {} is not valid",
+            rules_dir.display()
+        )
+    })?;
+    let missing_ids: Vec<_> = crate::config_loader::LOGS_JP_REQUIRED_RULE_IDS
+        .iter()
+        .copied()
+        .filter(|required_id| !rules.iter().any(|rule| rule.id == *required_id))
+        .collect();
+
+    if !missing_ids.is_empty() {
+        anyhow::bail!(
+            "Existing log RulePack at {} is missing required logs-jp rules: {}. Repair or remove rules/log, then rerun `veil init --preset logs-jp`.",
+            rules_dir.display(),
+            missing_ids.join(", ")
+        );
     }
+
     Ok(())
 }
 

--- a/crates/veil-cli/src/commands/init.rs
+++ b/crates/veil-cli/src/commands/init.rs
@@ -273,34 +273,20 @@ pub fn init(
     }
     let toml_str = toml::to_string_pretty(&config)?;
 
+    let should_init_log_pack =
+        answers.profile == Profile::Logs || preset.as_deref() == Some("logs-jp");
+    let log_pack_rules_dir = Path::new("rules/log");
+    let log_pack_created_any = if should_init_log_pack {
+        Some(ensure_log_pack_for_init(log_pack_rules_dir)?)
+    } else {
+        None
+    };
+
     let path = answers.target_path.as_deref().unwrap_or(path);
     fs::write(path, toml_str)?;
 
     // Post-generation for Logs profile or logs preset
-    if answers.profile == Profile::Logs || preset.as_deref() == Some("logs-jp") {
-        let rules_dir = Path::new("rules/log");
-        if !rules_dir.exists() {
-            fs::create_dir_all(rules_dir)?;
-            println!(
-                "{}",
-                format!("Created directory {}", rules_dir.display()).green()
-            );
-        }
-
-        let mut created_any = false;
-        for file in LogPackAssets::iter() {
-            let file_path = rules_dir.join(file.as_ref());
-            if !file_path.exists() {
-                if let Some(content) = LogPackAssets::get(file.as_ref()) {
-                    fs::write(&file_path, content.data.as_ref())?;
-                    println!("  - Created {}", file.as_ref());
-                    created_any = true;
-                }
-            }
-        }
-
-        validate_log_pack_for_init(rules_dir)?;
-
+    if let Some(created_any) = log_pack_created_any {
         if created_any {
             println!(
                 "{}",
@@ -315,7 +301,7 @@ pub fn init(
                 "{}",
                 format!(
                     "Directory {} already contains a usable log RulePack.",
-                    rules_dir.display()
+                    log_pack_rules_dir.display()
                 )
                 .yellow()
             );
@@ -333,6 +319,32 @@ pub fn init(
     }
 
     Ok(())
+}
+
+fn ensure_log_pack_for_init(rules_dir: &Path) -> Result<bool> {
+    if !rules_dir.exists() {
+        fs::create_dir_all(rules_dir)?;
+        println!(
+            "{}",
+            format!("Created directory {}", rules_dir.display()).green()
+        );
+    }
+
+    let mut created_any = false;
+    for file in LogPackAssets::iter() {
+        let file_path = rules_dir.join(file.as_ref());
+        if !file_path.exists() {
+            if let Some(content) = LogPackAssets::get(file.as_ref()) {
+                fs::write(&file_path, content.data.as_ref())?;
+                println!("  - Created {}", file.as_ref());
+                created_any = true;
+            }
+        }
+    }
+
+    validate_log_pack_for_init(rules_dir)?;
+
+    Ok(created_any)
 }
 
 fn validate_log_pack_for_init(rules_dir: &Path) -> Result<()> {

--- a/crates/veil-cli/src/commands/init.rs
+++ b/crates/veil-cli/src/commands/init.rs
@@ -238,10 +238,10 @@ pub fn init(
             "{}",
             "Tip: Run `veil init --wizard` for an interactive setup (recommended).".dimmed()
         );
-        if profile == Profile::Logs {
+        if profile == Profile::Logs || preset.as_deref() == Some("logs-jp") {
             println!(
                 "{}",
-                "Note: This profile generates a log-focused RulePack under rules/log.".dimmed()
+                "Note: This setup generates a log-focused RulePack under rules/log.".dimmed()
             );
         }
 
@@ -259,6 +259,9 @@ pub fn init(
     let mut config = build_config(&answers);
     if let Some(preset_id) = preset.as_deref() {
         config = veil_config::apply_builtin_preset_as_base(config, preset_id)?;
+        if preset_id == "logs-jp" && config.core.rules_dir.is_none() {
+            config.core.rules_dir = Some("rules/log".to_string());
+        }
         println!(
             "{}",
             format!(
@@ -283,8 +286,8 @@ pub fn init(
         println!("Policy: Fail on score >= {}", score);
     }
 
-    // Post-generation for Logs profile
-    if answers.profile == Profile::Logs {
+    // Post-generation for Logs profile or logs preset
+    if answers.profile == Profile::Logs || preset.as_deref() == Some("logs-jp") {
         let rules_dir = Path::new("rules/log");
         if !rules_dir.exists() {
             fs::create_dir_all(rules_dir)?;

--- a/crates/veil-cli/src/commands/scan.rs
+++ b/crates/veil-cli/src/commands/scan.rs
@@ -438,6 +438,8 @@ pub fn scan(
     fail_on_severity: Option<veil_core::Severity>,
     write_baseline: Option<PathBuf>,
     baseline: Option<PathBuf>,
+    preset: Option<String>,
+    quiet: bool,
     no_color: bool, // Passed from cli args
 ) -> Result<bool> {
     let format: Format = format_str.as_str().into();
@@ -454,8 +456,20 @@ pub fn scan(
     }
 
     // Load config here for scan command to support --config arg
-    let config = if let Some(path) = config_path {
-        Some(crate::config_loader::load_effective_config(Some(path))?)
+    let config = if config_path.is_some() || preset.is_some() {
+        let loaded = crate::config_loader::load_effective_config_with_preset(
+            config_path,
+            preset.as_deref(),
+        )?;
+        if let Some(preset_id) = preset.as_deref() {
+            if !quiet {
+                eprintln!(
+                    "Using preset '{}' as the base config layer; user/org/repo config may override it.",
+                    preset_id
+                );
+            }
+        }
+        Some(loaded)
     } else {
         None
     };

--- a/crates/veil-cli/src/config_loader.rs
+++ b/crates/veil-cli/src/config_loader.rs
@@ -4,6 +4,7 @@ use veil_config::{load_config, Config};
 
 #[derive(Debug, Clone)]
 pub struct ConfigLayers {
+    pub preset: Option<Config>,
     pub org: Option<Config>,
     pub user: Option<Config>,
     pub repo: Option<Config>,
@@ -12,12 +13,22 @@ pub struct ConfigLayers {
 
 /// New entry point for loading configuration with layers
 pub fn load_config_layers(explicit_path: Option<&PathBuf>) -> Result<ConfigLayers> {
+    load_config_layers_with_preset(explicit_path, None)
+}
+
+pub fn load_config_layers_with_preset(
+    explicit_path: Option<&PathBuf>,
+    preset_id: Option<&str>,
+) -> Result<ConfigLayers> {
+    let preset = preset_id
+        .map(veil_config::builtin_preset_config)
+        .transpose()?;
     let org = load_org_config()?;
     let user = load_user_config()?;
     let repo = load_repo_config(explicit_path)?;
 
-    // Merge logic: User -> Org -> Repo (later overrides earlier)
-    let mut effective = merge_configs(org.as_ref(), user.as_ref(), repo.as_ref());
+    // Merge logic: Preset -> User -> Org -> Repo (later overrides earlier)
+    let mut effective = merge_configs(preset.as_ref(), org.as_ref(), user.as_ref(), repo.as_ref());
 
     // Process rules_dir: Resolve to absolute path but do NOT load here.
     // Core will load the rule pack.
@@ -45,6 +56,7 @@ pub fn load_config_layers(explicit_path: Option<&PathBuf>) -> Result<ConfigLayer
     }
 
     Ok(ConfigLayers {
+        preset,
         org,
         user,
         repo,
@@ -57,8 +69,25 @@ pub fn load_effective_config(config_path: Option<&PathBuf>) -> Result<Config> {
     Ok(load_config_layers(config_path)?.effective)
 }
 
-fn merge_configs(org: Option<&Config>, user: Option<&Config>, repo: Option<&Config>) -> Config {
+pub fn load_effective_config_with_preset(
+    config_path: Option<&PathBuf>,
+    preset_id: Option<&str>,
+) -> Result<Config> {
+    Ok(load_config_layers_with_preset(config_path, preset_id)?.effective)
+}
+
+fn merge_configs(
+    preset: Option<&Config>,
+    org: Option<&Config>,
+    user: Option<&Config>,
+    repo: Option<&Config>,
+) -> Config {
     let mut final_config = Config::default();
+
+    // Layer 0: Preset Config (Product default for a scenario)
+    if let Some(preset_cfg) = preset {
+        final_config.merge(preset_cfg.clone());
+    }
 
     // Layer 1: User Config (Base Preferences)
     if let Some(user_cfg) = user {

--- a/crates/veil-cli/src/config_loader.rs
+++ b/crates/veil-cli/src/config_loader.rs
@@ -2,6 +2,13 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use veil_config::{load_config, Config};
 
+const LOGS_JP_REQUIRED_RULE_IDS: &[&str] = &[
+    "log.pii.jp.mynumber.keyword",
+    "log.pii.credit_card",
+    "log.pii.jp.phone.keyword",
+    "log.pii.jp.postal.keyword",
+];
+
 #[derive(Debug, Clone)]
 pub struct ConfigLayers {
     #[allow(dead_code)]
@@ -124,10 +131,16 @@ fn validate_logs_preset_rule_pack(config: &Config) -> Result<()> {
             path.display()
         )
     })?;
-    if !rules.iter().any(|rule| rule.id.starts_with("log.pii.")) {
+    let missing_ids: Vec<_> = LOGS_JP_REQUIRED_RULE_IDS
+        .iter()
+        .copied()
+        .filter(|required_id| !rules.iter().any(|rule| rule.id == *required_id))
+        .collect();
+    if !missing_ids.is_empty() {
         anyhow::bail!(
-            "Preset 'logs-jp' requires a log rule pack containing log.pii.* rules at {}. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\".",
-            path.display()
+            "Preset 'logs-jp' requires a log rule pack containing these rules at {}: {}. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\".",
+            path.display(),
+            missing_ids.join(", ")
         );
     }
 

--- a/crates/veil-cli/src/config_loader.rs
+++ b/crates/veil-cli/src/config_loader.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use veil_config::{load_config, Config};
 
@@ -21,6 +21,21 @@ pub fn load_config_layers_with_preset(
     explicit_path: Option<&PathBuf>,
     preset_id: Option<&str>,
 ) -> Result<ConfigLayers> {
+    load_config_layers_with_preset_inner(explicit_path, preset_id, true)
+}
+
+pub fn load_config_layers_with_preset_for_dump(
+    explicit_path: Option<&PathBuf>,
+    preset_id: Option<&str>,
+) -> Result<ConfigLayers> {
+    load_config_layers_with_preset_inner(explicit_path, preset_id, false)
+}
+
+fn load_config_layers_with_preset_inner(
+    explicit_path: Option<&PathBuf>,
+    preset_id: Option<&str>,
+    validate_runtime_assets: bool,
+) -> Result<ConfigLayers> {
     let preset = preset_id
         .map(veil_config::builtin_preset_config)
         .transpose()?;
@@ -30,10 +45,8 @@ pub fn load_config_layers_with_preset(
 
     // Merge logic: Preset -> User -> Org -> Repo (later overrides earlier)
     let mut effective = merge_configs(preset.as_ref(), org.as_ref(), user.as_ref(), repo.as_ref());
-    apply_preset_runtime_defaults(&mut effective, preset_id)?;
 
-    // Process rules_dir: Resolve to absolute path but do NOT load here.
-    // Core will load the rule pack.
+    // Resolve rules_dir before optional runtime asset validation and rule loading.
     if let Some(dir_str) = &effective.core.rules_dir {
         let base_dir = if let Some(p) = explicit_path {
             if p.is_file() {
@@ -57,6 +70,10 @@ pub fn load_config_layers_with_preset(
         }
     }
 
+    if validate_runtime_assets {
+        validate_preset_runtime_assets(&effective, preset_id)?;
+    }
+
     Ok(ConfigLayers {
         preset,
         org,
@@ -78,10 +95,39 @@ pub fn load_effective_config_with_preset(
     Ok(load_config_layers_with_preset(config_path, preset_id)?.effective)
 }
 
-fn apply_preset_runtime_defaults(config: &mut Config, preset_id: Option<&str>) -> Result<()> {
-    if preset_id == Some("logs-jp") && config.core.rules_dir.is_none() {
+fn validate_preset_runtime_assets(config: &Config, preset_id: Option<&str>) -> Result<()> {
+    if preset_id == Some("logs-jp") {
+        validate_logs_preset_rule_pack(config)?;
+    }
+
+    Ok(())
+}
+
+fn validate_logs_preset_rule_pack(config: &Config) -> Result<()> {
+    let Some(rules_dir) = &config.core.rules_dir else {
         anyhow::bail!(
             "Preset 'logs-jp' requires the log rule pack. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\"."
+        );
+    };
+
+    let path = Path::new(rules_dir);
+    if !path.is_dir() {
+        anyhow::bail!(
+            "Preset 'logs-jp' requires the log rule pack at {}. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\".",
+            path.display()
+        );
+    }
+
+    let rules = veil_core::rules::pack::load_rule_pack(path).with_context(|| {
+        format!(
+            "Preset 'logs-jp' requires a valid log rule pack at {}",
+            path.display()
+        )
+    })?;
+    if !rules.iter().any(|rule| rule.id.starts_with("log.pii.")) {
+        anyhow::bail!(
+            "Preset 'logs-jp' requires a log rule pack containing log.pii.* rules at {}. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\".",
+            path.display()
         );
     }
 

--- a/crates/veil-cli/src/config_loader.rs
+++ b/crates/veil-cli/src/config_loader.rs
@@ -80,25 +80,12 @@ pub fn load_effective_config_with_preset(
 
 fn apply_preset_runtime_defaults(config: &mut Config, preset_id: Option<&str>) -> Result<()> {
     if preset_id == Some("logs-jp") && config.core.rules_dir.is_none() {
-        let rules_dir = bundled_log_rules_dir();
-        if !rules_dir.is_dir() {
-            anyhow::bail!(
-                "Preset 'logs-jp' requires the log rule pack. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\"."
-            );
-        }
-        config.core.rules_dir = Some(rules_dir.to_string_lossy().to_string());
+        anyhow::bail!(
+            "Preset 'logs-jp' requires the log rule pack. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\"."
+        );
     }
 
     Ok(())
-}
-
-fn bundled_log_rules_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap_or(Path::new("."))
-        .join("veil")
-        .join("rules")
-        .join("log")
 }
 
 fn merge_configs(

--- a/crates/veil-cli/src/config_loader.rs
+++ b/crates/veil-cli/src/config_loader.rs
@@ -4,6 +4,7 @@ use veil_config::{load_config, Config};
 
 #[derive(Debug, Clone)]
 pub struct ConfigLayers {
+    #[allow(dead_code)]
     pub preset: Option<Config>,
     pub org: Option<Config>,
     pub user: Option<Config>,

--- a/crates/veil-cli/src/config_loader.rs
+++ b/crates/veil-cli/src/config_loader.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use veil_config::{load_config, Config};
 
-const LOGS_JP_REQUIRED_RULE_IDS: &[&str] = &[
+pub(crate) const LOGS_JP_REQUIRED_RULE_IDS: &[&str] = &[
     "log.pii.jp.mynumber.keyword",
     "log.pii.credit_card",
     "log.pii.jp.phone.keyword",

--- a/crates/veil-cli/src/config_loader.rs
+++ b/crates/veil-cli/src/config_loader.rs
@@ -29,6 +29,7 @@ pub fn load_config_layers_with_preset(
 
     // Merge logic: Preset -> User -> Org -> Repo (later overrides earlier)
     let mut effective = merge_configs(preset.as_ref(), org.as_ref(), user.as_ref(), repo.as_ref());
+    apply_preset_runtime_defaults(&mut effective, preset_id)?;
 
     // Process rules_dir: Resolve to absolute path but do NOT load here.
     // Core will load the rule pack.
@@ -74,6 +75,29 @@ pub fn load_effective_config_with_preset(
     preset_id: Option<&str>,
 ) -> Result<Config> {
     Ok(load_config_layers_with_preset(config_path, preset_id)?.effective)
+}
+
+fn apply_preset_runtime_defaults(config: &mut Config, preset_id: Option<&str>) -> Result<()> {
+    if preset_id == Some("logs-jp") && config.core.rules_dir.is_none() {
+        let rules_dir = bundled_log_rules_dir();
+        if !rules_dir.is_dir() {
+            anyhow::bail!(
+                "Preset 'logs-jp' requires the log rule pack. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\"."
+            );
+        }
+        config.core.rules_dir = Some(rules_dir.to_string_lossy().to_string());
+    }
+
+    Ok(())
+}
+
+fn bundled_log_rules_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap_or(Path::new("."))
+        .join("veil")
+        .join("rules")
+        .join("log")
 }
 
 fn merge_configs(

--- a/crates/veil-cli/src/main.rs
+++ b/crates/veil-cli/src/main.rs
@@ -41,6 +41,7 @@ fn main() -> anyhow::Result<()> {
     let result = match &cli.command {
         Some(Commands::Scan {
             paths,
+            preset,
             format,
             fail_score,
             commit,
@@ -73,6 +74,8 @@ fn main() -> anyhow::Result<()> {
                 fail_on_severity.clone(),
                 write_baseline.clone(),
                 baseline.clone(),
+                preset.clone(),
+                cli.quiet,
                 cli.no_color,
             )
         }
@@ -89,12 +92,14 @@ fn main() -> anyhow::Result<()> {
             non_interactive,
             ci,
             profile,
+            preset,
             pin_tag,
         }) => commands::init::init(
             *wizard,
             *non_interactive,
             ci.clone(),
             profile.clone(),
+            preset.clone(),
             pin_tag.clone(),
         )
         .map(|_| false),
@@ -106,9 +111,12 @@ fn main() -> anyhow::Result<()> {
                 let path = config_path.clone().or_else(|| cli.config.clone());
                 commands::config::check(path.as_ref())
             }
-            crate::cli::ConfigCommand::Dump { layer, format } => {
-                commands::config::dump(cli.config.as_ref(), *layer, *format).map(|_| false)
-            }
+            crate::cli::ConfigCommand::Dump {
+                preset,
+                layer,
+                format,
+            } => commands::config::dump(cli.config.as_ref(), preset.as_deref(), *layer, *format)
+                .map(|_| false),
         },
         Some(Commands::PreCommit(cmd)) => match cmd {
             crate::cli::PreCommitCommand::Init => commands::pre_commit::init().map(|_| false),

--- a/crates/veil-cli/tests/config_dump_test.rs
+++ b/crates/veil-cli/tests/config_dump_test.rs
@@ -36,6 +36,50 @@ fail_on_score = 88
 }
 
 #[test]
+fn config_dump_preset_layer_json() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.arg("config")
+        .arg("dump")
+        .arg("--preset")
+        .arg("fintech-jp")
+        .arg("--layer")
+        .arg("preset");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("pii.fin.credit_card.keyword"))
+        .stdout(predicate::str::contains("\"base_score\": 85"));
+}
+
+#[test]
+fn config_dump_effective_shows_repo_override_over_preset() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("veil.toml");
+
+    let config_toml = r#"
+[rules."pii.fin.credit_card.keyword"]
+enabled = true
+base_score = 99
+"#;
+    let mut file = File::create(&config_path).unwrap();
+    writeln!(file, "{}", config_toml).unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.current_dir(dir.path())
+        .arg("config")
+        .arg("dump")
+        .arg("--preset")
+        .arg("fintech-jp")
+        .arg("--layer")
+        .arg("effective");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"base_score\": 99"))
+        .stdout(predicate::str::contains("\"base_score\": 85").not());
+}
+
+#[test]
 fn config_dump_org_is_empty_by_default() {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
     cmd.arg("config").arg("dump").arg("--layer").arg("org");

--- a/crates/veil-cli/tests/config_dump_test.rs
+++ b/crates/veil-cli/tests/config_dump_test.rs
@@ -71,6 +71,24 @@ fn config_dump_preset_layer_ignores_external_config_errors() {
 }
 
 #[test]
+fn config_dump_logs_preset_effective_skips_rule_pack_validation() {
+    let dir = tempdir().unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.current_dir(dir.path())
+        .arg("config")
+        .arg("dump")
+        .arg("--preset")
+        .arg("logs-jp")
+        .arg("--layer")
+        .arg("effective");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("log.pii.credit_card"));
+}
+
+#[test]
 fn config_dump_effective_shows_repo_override_over_preset() {
     let dir = tempdir().unwrap();
     let config_path = dir.path().join("veil.toml");

--- a/crates/veil-cli/tests/config_dump_test.rs
+++ b/crates/veil-cli/tests/config_dump_test.rs
@@ -52,6 +52,25 @@ fn config_dump_preset_layer_json() {
 }
 
 #[test]
+fn config_dump_preset_layer_ignores_external_config_errors() {
+    let dir = tempdir().unwrap();
+    let missing_org_config = dir.path().join("missing-org.toml");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.env("VEIL_ORG_CONFIG", missing_org_config)
+        .arg("config")
+        .arg("dump")
+        .arg("--preset")
+        .arg("fintech-jp")
+        .arg("--layer")
+        .arg("preset");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("pii.fin.credit_card.keyword"));
+}
+
+#[test]
 fn config_dump_effective_shows_repo_override_over_preset() {
     let dir = tempdir().unwrap();
     let config_path = dir.path().join("veil.toml");

--- a/crates/veil-cli/tests/init_log_pack_test.rs
+++ b/crates/veil-cli/tests/init_log_pack_test.rs
@@ -129,3 +129,25 @@ fn test_init_logs_preset_generates_log_pack() {
     assert!(config_content.contains("base_score = 88"));
     assert!(dir_path.join("rules/log/00_manifest.toml").exists());
 }
+
+#[test]
+fn test_init_logs_preset_with_application_profile_generates_log_pack() {
+    let dir = tempdir().unwrap();
+    let dir_path = dir.path();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.current_dir(dir_path)
+        .arg("init")
+        .arg("--profile")
+        .arg("application")
+        .arg("--preset")
+        .arg("logs-jp")
+        .assert()
+        .success();
+
+    let config_content = fs::read_to_string(dir_path.join("veil.toml")).unwrap();
+    assert!(config_content.contains("rules_dir = \"rules/log\""));
+    assert!(config_content.contains("fail_on_score = 80"));
+    assert!(config_content.contains("[rules.\"log.pii.credit_card\"]"));
+    assert!(dir_path.join("rules/log/00_manifest.toml").exists());
+}

--- a/crates/veil-cli/tests/init_log_pack_test.rs
+++ b/crates/veil-cli/tests/init_log_pack_test.rs
@@ -90,3 +90,42 @@ fn test_init_app_profile_defaults() {
     // Default app profile should have fail_on_score = 80
     assert!(config_content.contains("fail_on_score = 80"));
 }
+
+#[test]
+fn test_init_fintech_preset_writes_rule_overrides() {
+    let dir = tempdir().unwrap();
+    let dir_path = dir.path();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.current_dir(dir_path)
+        .arg("init")
+        .arg("--preset")
+        .arg("fintech-jp")
+        .assert()
+        .success();
+
+    let config_content = fs::read_to_string(dir_path.join("veil.toml")).unwrap();
+    assert!(config_content.contains("[rules.\"pii.fin.credit_card.keyword\"]"));
+    assert!(config_content.contains("base_score = 85"));
+    assert!(!config_content.contains("severity ="));
+}
+
+#[test]
+fn test_init_logs_preset_generates_log_pack() {
+    let dir = tempdir().unwrap();
+    let dir_path = dir.path();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.current_dir(dir_path)
+        .arg("init")
+        .arg("--preset")
+        .arg("logs-jp")
+        .assert()
+        .success();
+
+    let config_content = fs::read_to_string(dir_path.join("veil.toml")).unwrap();
+    assert!(config_content.contains("rules_dir = \"rules/log\""));
+    assert!(config_content.contains("[rules.\"log.pii.credit_card\"]"));
+    assert!(config_content.contains("base_score = 88"));
+    assert!(dir_path.join("rules/log/00_manifest.toml").exists());
+}

--- a/crates/veil-cli/tests/init_log_pack_test.rs
+++ b/crates/veil-cli/tests/init_log_pack_test.rs
@@ -200,6 +200,7 @@ tags = ["log", "pii"]
         .unwrap();
 
     assert_eq!(output.status.code(), Some(2));
+    assert!(!dir_path.join("veil.toml").exists());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("missing required logs-jp rules"));
     assert!(stderr.contains("log.pii.credit_card"));

--- a/crates/veil-cli/tests/init_log_pack_test.rs
+++ b/crates/veil-cli/tests/init_log_pack_test.rs
@@ -151,3 +151,56 @@ fn test_init_logs_preset_with_application_profile_generates_log_pack() {
     assert!(config_content.contains("[rules.\"log.pii.credit_card\"]"));
     assert!(dir_path.join("rules/log/00_manifest.toml").exists());
 }
+
+#[test]
+fn test_init_logs_preset_fills_existing_empty_log_pack_dir() {
+    let dir = tempdir().unwrap();
+    let dir_path = dir.path();
+    fs::create_dir_all(dir_path.join("rules/log")).unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.current_dir(dir_path)
+        .arg("init")
+        .arg("--preset")
+        .arg("logs-jp")
+        .assert()
+        .success();
+
+    assert!(dir_path.join("rules/log/00_manifest.toml").exists());
+    assert!(dir_path.join("rules/log/pii.toml").exists());
+}
+
+#[test]
+fn test_init_logs_preset_fails_existing_stale_log_pack() {
+    let dir = tempdir().unwrap();
+    let dir_path = dir.path();
+    let rules_dir = dir_path.join("rules/log");
+    fs::create_dir_all(&rules_dir).unwrap();
+    fs::write(
+        rules_dir.join("pii.toml"),
+        r#"
+[[rules]]
+id = "log.pii.email"
+description = "Email in logs"
+pattern = '''[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}'''
+severity = "LOW"
+score = 40
+category = "log_pii"
+tags = ["log", "pii"]
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_veil"))
+        .current_dir(dir_path)
+        .arg("init")
+        .arg("--preset")
+        .arg("logs-jp")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("missing required logs-jp rules"));
+    assert!(stderr.contains("log.pii.credit_card"));
+}

--- a/crates/veil-cli/tests/init_test.rs
+++ b/crates/veil-cli/tests/init_test.rs
@@ -69,3 +69,25 @@ fn test_init_ci_unsupported() {
         .failure()
         .stderr(predicate::str::contains("Unsupported CI provider"));
 }
+
+#[test]
+fn test_init_ci_rejects_preset_combination() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.current_dir(temp_path)
+        .arg("init")
+        .arg("--preset")
+        .arg("logs-jp")
+        .arg("--ci")
+        .arg("github");
+
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "--preset cannot be combined with --ci",
+    ));
+
+    assert!(!temp_path.join("veil.toml").exists());
+    assert!(!temp_path.join("rules/log").exists());
+    assert!(!temp_path.join(".github/workflows/veil.yml").exists());
+}

--- a/crates/veil-cli/tests/preset_cli_test.rs
+++ b/crates/veil-cli/tests/preset_cli_test.rs
@@ -1,0 +1,48 @@
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn scan_preset_applies_rule_base_score() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("card.txt"), "card: 4111222233334448\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_veil"))
+        .current_dir(dir.path())
+        .arg("--quiet")
+        .arg("scan")
+        .arg(".")
+        .arg("--preset")
+        .arg("fintech-jp")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json["findings"][0]["rule_id"],
+        "pii.fin.credit_card.keyword"
+    );
+    assert_eq!(json["findings"][0]["score"], 85);
+}
+
+#[test]
+fn scan_unknown_preset_fails_fast() {
+    let dir = tempdir().unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_veil"))
+        .current_dir(dir.path())
+        .arg("scan")
+        .arg(".")
+        .arg("--preset")
+        .arg("minimal-ci")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unknown preset 'minimal-ci'"));
+}

--- a/crates/veil-cli/tests/preset_cli_test.rs
+++ b/crates/veil-cli/tests/preset_cli_test.rs
@@ -124,6 +124,48 @@ fn scan_logs_preset_with_empty_rules_dir_fails_with_guidance() {
 
     assert_eq!(output.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("log.pii.*"));
+    assert!(stderr.contains("log.pii.credit_card"));
+    assert!(stderr.contains("veil init --preset logs-jp"));
+}
+
+#[test]
+fn scan_logs_preset_requires_overridden_log_rule_ids() {
+    let dir = tempdir().unwrap();
+    let rules_dir = dir.path().join("rules/custom");
+    fs::create_dir_all(&rules_dir).unwrap();
+    fs::write(
+        rules_dir.join("custom.toml"),
+        r#"
+[[rules]]
+id = "log.pii.email"
+description = "Email in logs"
+pattern = '''[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}'''
+severity = "LOW"
+score = 40
+category = "log_pii"
+tags = ["log", "pii"]
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("veil.toml"),
+        "[core]\nrules_dir = \"rules/custom\"\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("app.log"), "payment=4111222233334448\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_veil"))
+        .current_dir(dir.path())
+        .arg("scan")
+        .arg(".")
+        .arg("--preset")
+        .arg("logs-jp")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("log.pii.credit_card"));
+    assert!(stderr.contains("log.pii.jp.mynumber.keyword"));
     assert!(stderr.contains("veil init --preset logs-jp"));
 }

--- a/crates/veil-cli/tests/preset_cli_test.rs
+++ b/crates/veil-cli/tests/preset_cli_test.rs
@@ -46,3 +46,30 @@ fn scan_unknown_preset_fails_fast() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Unknown preset 'minimal-ci'"));
 }
+
+#[test]
+fn scan_logs_preset_loads_log_rule_pack() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("app.log"), "payment=4111222233334448\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_veil"))
+        .current_dir(dir.path())
+        .arg("--quiet")
+        .arg("scan")
+        .arg(".")
+        .arg("--preset")
+        .arg("logs-jp")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    let log_card = findings
+        .iter()
+        .find(|finding| finding["rule_id"] == "log.pii.credit_card")
+        .unwrap();
+    assert!(log_card["score"].as_u64().unwrap() >= 88);
+}

--- a/crates/veil-cli/tests/preset_cli_test.rs
+++ b/crates/veil-cli/tests/preset_cli_test.rs
@@ -101,3 +101,29 @@ fn scan_logs_preset_without_rule_pack_fails_with_guidance() {
     assert!(stderr.contains("Preset 'logs-jp' requires the log rule pack"));
     assert!(stderr.contains("veil init --preset logs-jp"));
 }
+
+#[test]
+fn scan_logs_preset_with_empty_rules_dir_fails_with_guidance() {
+    let dir = tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("rules/empty")).unwrap();
+    fs::write(
+        dir.path().join("veil.toml"),
+        "[core]\nrules_dir = \"rules/empty\"\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("app.log"), "payment=4111222233334448\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_veil"))
+        .current_dir(dir.path())
+        .arg("scan")
+        .arg(".")
+        .arg("--preset")
+        .arg("logs-jp")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("log.pii.*"));
+    assert!(stderr.contains("veil init --preset logs-jp"));
+}

--- a/crates/veil-cli/tests/preset_cli_test.rs
+++ b/crates/veil-cli/tests/preset_cli_test.rs
@@ -50,6 +50,14 @@ fn scan_unknown_preset_fails_fast() {
 #[test]
 fn scan_logs_preset_loads_log_rule_pack() {
     let dir = tempdir().unwrap();
+    Command::new(env!("CARGO_BIN_EXE_veil"))
+        .current_dir(dir.path())
+        .arg("init")
+        .arg("--preset")
+        .arg("logs-jp")
+        .assert()
+        .success();
+
     fs::write(dir.path().join("app.log"), "payment=4111222233334448\n").unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_veil"))
@@ -72,4 +80,24 @@ fn scan_logs_preset_loads_log_rule_pack() {
         .find(|finding| finding["rule_id"] == "log.pii.credit_card")
         .unwrap();
     assert!(log_card["score"].as_u64().unwrap() >= 88);
+}
+
+#[test]
+fn scan_logs_preset_without_rule_pack_fails_with_guidance() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("app.log"), "payment=4111222233334448\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_veil"))
+        .current_dir(dir.path())
+        .arg("scan")
+        .arg(".")
+        .arg("--preset")
+        .arg("logs-jp")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Preset 'logs-jp' requires the log rule pack"));
+    assert!(stderr.contains("veil init --preset logs-jp"));
 }

--- a/docs/pr/PR-104-jp-preset-cli-ux.md
+++ b/docs/pr/PR-104-jp-preset-cli-ux.md
@@ -1,0 +1,51 @@
+# PR-104: JP preset CLI UX
+
+## Why
+- Operators need a direct way to apply JP presets during scan and init workflows.
+- Preset behavior must remain explainable through config layer inspection.
+- CLI UX should be added only after validator and preset resolver contracts are stable.
+
+## Summary
+- Add CLI flags for applying built-in presets.
+- Make preset config visible as its own layer.
+- Keep the preset as a base layer so user, org, and repo config can override it.
+
+## Changes
+- Add `veil scan --preset <ID>`.
+- Add `veil init --preset <ID>`.
+- Add `veil config dump --preset <ID> --layer preset`.
+- Allow `veil config dump --preset <ID> --layer effective` to show merged results.
+- Use `logs-jp` to generate the log rule pack during init.
+- Add CLI tests for preset scan scoring, unknown preset failure, config dump visibility, and init output.
+
+## Non-goals
+- No new preset fields beyond PR #103.
+- No server/API preset execution beyond the existing explicit rejection.
+- No extra preset policy layer semantics beyond base-layer config merge.
+
+## Impact / Scope
+- CLI: scan, init, and config dump gain preset flags.
+- CI: adds CLI tests for preset UX and config layer behavior.
+- Docs: SOT only.
+- Rules: no direct rule changes in this PR.
+- Tests: CLI-focused integration tests.
+
+## Verification
+
+### Commands
+```bash
+cargo fmt --all --check
+cargo test -p veil-cli
+cargo test -p veil-core scanner::
+cargo test --workspace
+python scripts/check_generated_schemas.py
+cargo run -p veil-cli -- verify tests/fixtures/evidence/golden.zip --require-complete
+npm --prefix crates/veil-pro/frontend run build
+```
+
+### Evidence
+- Local validation passed before opening the draft PR.
+- This PR is stacked on PR #103.
+
+## Rollback
+- Revert this PR to remove preset CLI UX while keeping preset resolver support from PR #103.


### PR DESCRIPTION
## Summary
- add `veil scan --preset <ID>` and load the selected built-in preset as the base config layer
- add `veil init --preset <ID>` so generated configs can include preset rule overrides; `logs-jp` generates the log rule pack
- add `veil config dump --preset <ID> --layer preset|effective` so operators can inspect the preset layer and merged result

## Scope
- includes CLI UX and config layer visibility for presets
- keeps the preset data contract from PR #2: rule overrides use only `enabled` and `base_score`
- does not add server/API preset execution beyond the existing explicit rejection

## Validation
- `cargo fmt --all --check`
- `cargo test -p veil-cli`
- `cargo test -p veil-core scanner::`
- `cargo test --workspace`
- `python scripts/check_generated_schemas.py`
- `cargo run -p veil-cli -- verify tests/fixtures/evidence/golden.zip --require-complete`
- `npm --prefix crates/veil-pro/frontend run build`

### SOT
- docs/pr/PR-104-jp-preset-cli-ux.md