### PR TITLE
Support JP presets in Local API scan

### DIFF
--- a/crates/veil-cli/src/commands/init.rs
+++ b/crates/veil-cli/src/commands/init.rs
@@ -388,7 +388,7 @@ fn validate_log_pack_for_init(rules_dir: &Path) -> Result<()> {
             rules_dir.display()
         )
     })?;
-    let missing_ids: Vec<_> = crate::config_loader::LOGS_JP_REQUIRED_RULE_IDS
+    let missing_ids: Vec<_> = veil_config::LOGS_JP_REQUIRED_RULE_IDS
         .iter()
         .copied()
         .filter(|required_id| !rules.iter().any(|rule| rule.id == *required_id))

--- a/crates/veil-cli/src/config_loader.rs
+++ b/crates/veil-cli/src/config_loader.rs
@@ -2,13 +2,6 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use veil_config::{load_config, Config};
 
-pub(crate) const LOGS_JP_REQUIRED_RULE_IDS: &[&str] = &[
-    "log.pii.jp.mynumber.keyword",
-    "log.pii.credit_card",
-    "log.pii.jp.phone.keyword",
-    "log.pii.jp.postal.keyword",
-];
-
 #[derive(Debug, Clone)]
 pub struct ConfigLayers {
     #[allow(dead_code)]
@@ -131,7 +124,7 @@ fn validate_logs_preset_rule_pack(config: &Config) -> Result<()> {
             path.display()
         )
     })?;
-    let missing_ids: Vec<_> = LOGS_JP_REQUIRED_RULE_IDS
+    let missing_ids: Vec<_> = veil_config::LOGS_JP_REQUIRED_RULE_IDS
         .iter()
         .copied()
         .filter(|required_id| !rules.iter().any(|rule| rule.id == *required_id))

--- a/crates/veil-config/src/lib.rs
+++ b/crates/veil-config/src/lib.rs
@@ -5,4 +5,7 @@ pub mod validate;
 
 pub use config::{Config, MaskMode, OutputConfig, RuleConfig};
 pub use loader::load_config;
-pub use presets::{apply_builtin_preset_as_base, builtin_preset_config, BUILTIN_PRESET_IDS};
+pub use presets::{
+    apply_builtin_preset_as_base, builtin_preset_config, BUILTIN_PRESET_IDS,
+    LOGS_JP_REQUIRED_RULE_IDS,
+};

--- a/crates/veil-config/src/presets.rs
+++ b/crates/veil-config/src/presets.rs
@@ -120,6 +120,19 @@ mod tests {
     }
 
     #[test]
+    fn logs_jp_required_rule_ids_are_present_in_preset_overrides() {
+        let config = builtin_preset_config("logs-jp").unwrap();
+
+        for required_id in LOGS_JP_REQUIRED_RULE_IDS {
+            assert!(
+                config.rules.contains_key(*required_id),
+                "logs-jp preset should override required log rule '{}'",
+                required_id
+            );
+        }
+    }
+
+    #[test]
     fn unknown_builtin_preset_errors() {
         let err = builtin_preset_config("minimal-ci").unwrap_err();
         assert!(err.to_string().contains("Unknown preset 'minimal-ci'"));

--- a/crates/veil-config/src/presets.rs
+++ b/crates/veil-config/src/presets.rs
@@ -11,6 +11,13 @@ pub const BUILTIN_PRESET_IDS: &[&str] = &[
     "si-vendor-jp",
 ];
 
+pub const LOGS_JP_REQUIRED_RULE_IDS: &[&str] = &[
+    "log.pii.jp.mynumber.keyword",
+    "log.pii.credit_card",
+    "log.pii.jp.phone.keyword",
+    "log.pii.jp.postal.keyword",
+];
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PresetFile {

--- a/crates/veil-pro/frontend/src/lib/ScanView.svelte
+++ b/crates/veil-pro/frontend/src/lib/ScanView.svelte
@@ -3,9 +3,11 @@
   
   // Strict State Machine for UI prediction and tracking (no implicit states)
   type ScanState = 'Idle' | 'Running' | 'SuccessNoFindings' | 'Violation' | 'Incomplete' | 'ErrorAuth' | 'ErrorConfig' | 'ErrorExpired' | 'ErrorOOM' | 'ErrorUnknown';
+  type ScanPreset = '' | 'standard-jp' | 'fintech-jp' | 'gov-jp' | 'si-vendor-jp' | 'logs-jp';
   let currentState = $state<ScanState>('Idle');
   
   let scanPath = $state('');
+  let scanPreset = $state<ScanPreset>('');
   let findings = $state<any[]>([]);
   let scanStats = $state<{scanned: number, skipped: number, runId: string} | null>(null);
   let errorMsg = $state<string | null>(null);
@@ -57,10 +59,15 @@
         headers['Authorization'] = `Bearer ${token}`;
       }
 
+      const requestBody: { paths: string[]; preset?: ScanPreset } = { paths: [targetPath] };
+      if (scanPreset !== '') {
+        requestBody.preset = scanPreset;
+      }
+
       const res = await fetch('/api/scan', {
         method: 'POST',
         headers,
-        body: JSON.stringify({ paths: [targetPath] })
+        body: JSON.stringify(requestBody)
       });
 
       if (res.status === 401) {
@@ -166,6 +173,14 @@
         placeholder="Enter path (e.g., /src or default '.') " 
         disabled={currentState === 'Running'}
       />
+      <select bind:value={scanPreset} aria-label="Preset" disabled={currentState === 'Running'}>
+        <option value="">Default</option>
+        <option value="standard-jp">standard-jp</option>
+        <option value="fintech-jp">fintech-jp</option>
+        <option value="gov-jp">gov-jp</option>
+        <option value="si-vendor-jp">si-vendor-jp</option>
+        <option value="logs-jp">logs-jp</option>
+      </select>
       <button type="submit" class="btn btn-primary" disabled={currentState === 'Running'}>
         {#if currentState === 'Running'}
           <Loader2 size={18} class="spin" /> Scanning...
@@ -292,11 +307,13 @@
   }
 
   .scan-form {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(160px, 220px) auto;
     gap: 12px;
   }
 
-  input[type="text"] {
+  input[type="text"],
+  select {
     flex: 1;
     padding: 12px 16px;
     border-radius: var(--radius-sm);
@@ -308,14 +325,31 @@
     transition: box-shadow 0.2s, border-color 0.2s;
   }
 
-  input[type="text"]:focus {
+  select {
+    appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%), linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%);
+    background-position: calc(100% - 18px) 50%, calc(100% - 13px) 50%;
+    background-size: 5px 5px, 5px 5px;
+    background-repeat: no-repeat;
+    padding-right: 36px;
+  }
+
+  input[type="text"]:focus,
+  select:focus {
     outline: none;
     box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.3);
     border-color: var(--accent);
   }
   
-  input[type="text"]:disabled {
+  input[type="text"]:disabled,
+  select:disabled {
     opacity: 0.6;
+  }
+
+  @media (max-width: 720px) {
+    .scan-form {
+      grid-template-columns: 1fr;
+    }
   }
 
   .btn { gap: 8px; }

--- a/crates/veil-pro/frontend/src/lib/ScanView.svelte
+++ b/crates/veil-pro/frontend/src/lib/ScanView.svelte
@@ -3,7 +3,8 @@
   
   // Strict State Machine for UI prediction and tracking (no implicit states)
   type ScanState = 'Idle' | 'Running' | 'SuccessNoFindings' | 'Violation' | 'Incomplete' | 'ErrorAuth' | 'ErrorConfig' | 'ErrorExpired' | 'ErrorOOM' | 'ErrorUnknown';
-  type ScanPreset = '' | 'standard-jp' | 'fintech-jp' | 'gov-jp' | 'si-vendor-jp' | 'logs-jp';
+  type ScanPresetId = 'standard-jp' | 'fintech-jp' | 'gov-jp' | 'si-vendor-jp' | 'logs-jp';
+  type ScanPreset = '' | ScanPresetId;
   let currentState = $state<ScanState>('Idle');
   
   let scanPath = $state('');
@@ -59,7 +60,7 @@
         headers['Authorization'] = `Bearer ${token}`;
       }
 
-      const requestBody: { paths: string[]; preset?: ScanPreset } = { paths: [targetPath] };
+      const requestBody: { paths: string[]; preset?: ScanPresetId } = { paths: [targetPath] };
       if (scanPreset !== '') {
         requestBody.preset = scanPreset;
       }

--- a/crates/veil-pro/src/api.rs
+++ b/crates/veil-pro/src/api.rs
@@ -101,6 +101,16 @@ fn normalized_paths(paths: Option<Vec<String>>) -> Vec<String> {
     }
 }
 
+fn preset_name(preset: PresetName) -> &'static str {
+    match preset {
+        PresetName::StandardJp => "standard-jp",
+        PresetName::FintechJp => "fintech-jp",
+        PresetName::GovJp => "gov-jp",
+        PresetName::SiVendorJp => "si-vendor-jp",
+        PresetName::LogsJp => "logs-jp",
+    }
+}
+
 fn scan_path_for_request(requested: &str, safe_path: &FsPath) -> PathBuf {
     let requested_path = PathBuf::from(requested);
     if !requested_path.is_absolute() {
@@ -161,6 +171,81 @@ fn load_effective_config_for_paths(
     paths: &[String],
 ) -> Result<veil_config::Config, ApiErrorResponse> {
     Ok(load_config_layers_for_api(paths)?.effective)
+}
+
+fn load_effective_config_for_paths_with_preset(
+    paths: &[String],
+    preset: Option<PresetName>,
+) -> Result<veil_config::Config, ApiErrorResponse> {
+    let config = load_effective_config_for_paths(paths)?;
+    let Some(preset) = preset else {
+        return Ok(config);
+    };
+    let preset_name = preset_name(preset);
+    let config = veil_config::apply_builtin_preset_as_base(config, preset_name)
+        .map_err(config_error_response)?;
+    validate_preset_runtime_assets_for_api(&config, preset_name)?;
+
+    Ok(config)
+}
+
+fn validate_preset_runtime_assets_for_api(
+    config: &veil_config::Config,
+    preset_name: &str,
+) -> Result<(), ApiErrorResponse> {
+    if preset_name == "logs-jp" {
+        validate_logs_preset_rule_pack_for_api(config)?;
+    }
+
+    Ok(())
+}
+
+fn logs_preset_config_error(message: impl Into<String>) -> ApiErrorResponse {
+    error_response(
+        StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidRequest,
+        message,
+        None,
+    )
+}
+
+fn validate_logs_preset_rule_pack_for_api(
+    config: &veil_config::Config,
+) -> Result<(), ApiErrorResponse> {
+    let Some(rules_dir) = &config.core.rules_dir else {
+        return Err(logs_preset_config_error(
+            "Preset 'logs-jp' requires the log rule pack. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\".",
+        ));
+    };
+
+    let path = FsPath::new(rules_dir);
+    if !path.is_dir() {
+        return Err(logs_preset_config_error(format!(
+            "Preset 'logs-jp' requires the log rule pack at {}. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\".",
+            path.display()
+        )));
+    }
+
+    let rules = veil_core::rules::pack::load_rule_pack(path).map_err(|err| {
+        logs_preset_config_error(format!(
+            "Preset 'logs-jp' requires a valid log rule pack at {}: {err}",
+            path.display()
+        ))
+    })?;
+    let missing_ids: Vec<_> = veil_config::LOGS_JP_REQUIRED_RULE_IDS
+        .iter()
+        .copied()
+        .filter(|required_id| !rules.iter().any(|rule| rule.id == *required_id))
+        .collect();
+    if !missing_ids.is_empty() {
+        return Err(logs_preset_config_error(format!(
+            "Preset 'logs-jp' requires a log rule pack containing these rules at {}: {}. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\".",
+            path.display(),
+            missing_ids.join(", ")
+        )));
+    }
+
+    Ok(())
 }
 
 fn baseline_file_error_response(error: BaselineFileError) -> ApiErrorResponse {
@@ -524,23 +609,6 @@ pub async fn scan_project(
             None,
         ));
     }
-    if let Some(preset) = req.preset {
-        let preset_name = match preset {
-            PresetName::StandardJp => "standard-jp",
-            PresetName::FintechJp => "fintech-jp",
-            PresetName::GovJp => "gov-jp",
-            PresetName::SiVendorJp => "si-vendor-jp",
-            PresetName::LogsJp => "logs-jp",
-        };
-        return Err(error_response(
-            StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidRequest,
-            format!(
-                "preset {preset_name} is not implemented by the Local API in PR-0; configure rules through veil.toml for this contract alignment release."
-            ),
-            None,
-        ));
-    }
     if req.fail_on_findings == Some(0) {
         return Err(error_response(
             StatusCode::BAD_REQUEST,
@@ -558,7 +626,7 @@ pub async fn scan_project(
         ));
     }
 
-    let config = load_effective_config_for_paths(&paths_to_scan)?;
+    let config = load_effective_config_for_paths_with_preset(&paths_to_scan, req.preset)?;
     let rules = load_rules_for_api(&config)?;
     let rules_by_id = rule_lookup(&rules);
     let baseline = resolve_baseline_file(req.baseline_file.as_deref())
@@ -1160,6 +1228,22 @@ mod tests {
     }
 
     #[test]
+    fn local_api_fintech_preset_applies_base_score_override() {
+        let config = load_effective_config_for_paths_with_preset(
+            &[".".to_string()],
+            Some(PresetName::FintechJp),
+        )
+        .unwrap();
+        let rules = load_rules_for_api(&config).unwrap();
+        let card_rule = rules
+            .iter()
+            .find(|rule| rule.id == "pii.fin.credit_card.keyword")
+            .unwrap();
+
+        assert_eq!(card_rule.base_score, Some(85));
+    }
+
+    #[test]
     fn discovered_invalid_baseline_returns_error() {
         let root = unique_target_dir("invalid-discovered-baseline");
         std::fs::write(
@@ -1530,7 +1614,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scan_rejects_unimplemented_preset() {
+    async fn scan_logs_preset_without_rule_pack_returns_guidance() {
         let state = Arc::new(AppState {
             token: "test-token".to_string(),
             run_cache: Arc::new(tokio::sync::RwLock::new(crate::evidence::RunCache::new(
@@ -1539,7 +1623,7 @@ mod tests {
             oauth: Arc::new(crate::auth::init_oauth()),
         });
         let request = ScanRequest {
-            preset: Some(PresetName::FintechJp),
+            preset: Some(PresetName::LogsJp),
             ..ScanRequest::default()
         };
 
@@ -1549,7 +1633,11 @@ mod tests {
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(matches!(body.error.code, ErrorCode::InvalidRequest));
-        assert!(body.error.message.contains("preset fintech-jp"));
+        assert!(body
+            .error
+            .message
+            .contains("Preset 'logs-jp' requires the log rule pack"));
+        assert!(body.error.message.contains("veil init --preset logs-jp"));
     }
 
     #[tokio::test]

--- a/crates/veil-pro/src/api.rs
+++ b/crates/veil-pro/src/api.rs
@@ -152,7 +152,29 @@ fn rules_error_response(error: impl std::fmt::Display) -> ApiErrorResponse {
 fn load_rules_for_api(
     config: &veil_config::Config,
 ) -> Result<Vec<veil_core::Rule>, ApiErrorResponse> {
-    veil_core::try_get_all_rules(config, vec![]).map_err(rules_error_response)
+    load_rules_for_api_with_extra(config, Vec::new())
+}
+
+fn load_rules_for_api_with_extra(
+    config: &veil_config::Config,
+    extra_rules: Vec<veil_core::Rule>,
+) -> Result<Vec<veil_core::Rule>, ApiErrorResponse> {
+    veil_core::try_get_all_rules(config, extra_rules).map_err(rules_error_response)
+}
+
+fn load_rules_for_scan_with_preset(
+    config: &veil_config::Config,
+    preset: Option<PresetName>,
+) -> Result<Vec<veil_core::Rule>, ApiErrorResponse> {
+    let preset_name = preset.map(preset_name);
+    let extra_rules = validate_preset_runtime_assets_for_api(config, preset_name)?;
+    if extra_rules.is_empty() {
+        return load_rules_for_api(config);
+    }
+
+    let mut config_without_rules_dir = config.clone();
+    config_without_rules_dir.core.rules_dir = None;
+    load_rules_for_api_with_extra(&config_without_rules_dir, extra_rules)
 }
 
 fn load_config_layers_for_api(_paths: &[String]) -> Result<ConfigLayers, ApiErrorResponse> {
@@ -191,20 +213,19 @@ fn apply_request_preset_for_api(
     let preset_name = preset_name(preset);
     let config = veil_config::apply_builtin_preset_as_base(config, preset_name)
         .map_err(config_error_response)?;
-    validate_preset_runtime_assets_for_api(&config, preset_name)?;
 
     Ok(config)
 }
 
 fn validate_preset_runtime_assets_for_api(
     config: &veil_config::Config,
-    preset_name: &str,
-) -> Result<(), ApiErrorResponse> {
-    if preset_name == "logs-jp" {
-        validate_logs_preset_rule_pack_for_api(config)?;
+    preset_name: Option<&str>,
+) -> Result<Vec<veil_core::Rule>, ApiErrorResponse> {
+    if preset_name == Some("logs-jp") {
+        return validate_logs_preset_rule_pack_for_api(config);
     }
 
-    Ok(())
+    Ok(Vec::new())
 }
 
 fn logs_preset_config_error(message: impl Into<String>) -> ApiErrorResponse {
@@ -218,7 +239,7 @@ fn logs_preset_config_error(message: impl Into<String>) -> ApiErrorResponse {
 
 fn validate_logs_preset_rule_pack_for_api(
     config: &veil_config::Config,
-) -> Result<(), ApiErrorResponse> {
+) -> Result<Vec<veil_core::Rule>, ApiErrorResponse> {
     let Some(rules_dir) = &config.core.rules_dir else {
         return Err(logs_preset_config_error(
             "Preset 'logs-jp' requires the log rule pack. Run `veil init --preset logs-jp` or set [core] rules_dir = \"rules/log\".",
@@ -252,7 +273,7 @@ fn validate_logs_preset_rule_pack_for_api(
         )));
     }
 
-    Ok(())
+    Ok(rules)
 }
 
 fn baseline_file_error_response(error: BaselineFileError) -> ApiErrorResponse {
@@ -634,7 +655,7 @@ pub async fn scan_project(
     }
 
     let config = load_effective_config_for_paths_with_preset(&paths_to_scan, req.preset)?;
-    let rules = load_rules_for_api(&config)?;
+    let rules = load_rules_for_scan_with_preset(&config, req.preset)?;
     let rules_by_id = rule_lookup(&rules);
     let baseline = resolve_baseline_file(req.baseline_file.as_deref())
         .map_err(baseline_file_error_response)?;
@@ -1640,9 +1661,11 @@ mod tests {
 
     #[test]
     fn local_api_logs_preset_without_rule_pack_returns_guidance() {
-        let (status, Json(body)) =
+        let config =
             apply_request_preset_for_api(veil_config::Config::default(), Some(PresetName::LogsJp))
-                .unwrap_err();
+                .unwrap();
+        let (status, Json(body)) =
+            load_rules_for_scan_with_preset(&config, Some(PresetName::LogsJp)).unwrap_err();
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(matches!(body.error.code, ErrorCode::InvalidRequest));

--- a/crates/veil-pro/src/api.rs
+++ b/crates/veil-pro/src/api.rs
@@ -178,6 +178,13 @@ fn load_effective_config_for_paths_with_preset(
     preset: Option<PresetName>,
 ) -> Result<veil_config::Config, ApiErrorResponse> {
     let config = load_effective_config_for_paths(paths)?;
+    apply_request_preset_for_api(config, preset)
+}
+
+fn apply_request_preset_for_api(
+    config: veil_config::Config,
+    preset: Option<PresetName>,
+) -> Result<veil_config::Config, ApiErrorResponse> {
     let Some(preset) = preset else {
         return Ok(config);
     };
@@ -1229,8 +1236,8 @@ mod tests {
 
     #[test]
     fn local_api_fintech_preset_applies_base_score_override() {
-        let config = load_effective_config_for_paths_with_preset(
-            &[".".to_string()],
+        let config = apply_request_preset_for_api(
+            veil_config::Config::default(),
             Some(PresetName::FintechJp),
         )
         .unwrap();
@@ -1613,23 +1620,11 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn scan_logs_preset_without_rule_pack_returns_guidance() {
-        let state = Arc::new(AppState {
-            token: "test-token".to_string(),
-            run_cache: Arc::new(tokio::sync::RwLock::new(crate::evidence::RunCache::new(
-                1, 1024, 1,
-            ))),
-            oauth: Arc::new(crate::auth::init_oauth()),
-        });
-        let request = ScanRequest {
-            preset: Some(PresetName::LogsJp),
-            ..ScanRequest::default()
-        };
-
-        let (status, Json(body)) = scan_project(State(state), Ok(Json(request)))
-            .await
-            .unwrap_err();
+    #[test]
+    fn local_api_logs_preset_without_rule_pack_returns_guidance() {
+        let (status, Json(body)) =
+            apply_request_preset_for_api(veil_config::Config::default(), Some(PresetName::LogsJp))
+                .unwrap_err();
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(matches!(body.error.code, ErrorCode::InvalidRequest));

--- a/crates/veil-pro/src/api.rs
+++ b/crates/veil-pro/src/api.rs
@@ -1235,6 +1235,24 @@ mod tests {
     }
 
     #[test]
+    fn local_api_preset_names_match_builtin_preset_ids() {
+        let api_ids: std::collections::BTreeSet<_> = [
+            PresetName::StandardJp,
+            PresetName::FintechJp,
+            PresetName::GovJp,
+            PresetName::SiVendorJp,
+            PresetName::LogsJp,
+        ]
+        .into_iter()
+        .map(preset_name)
+        .collect();
+        let builtin_ids: std::collections::BTreeSet<_> =
+            veil_config::BUILTIN_PRESET_IDS.iter().copied().collect();
+
+        assert_eq!(api_ids, builtin_ids);
+    }
+
+    #[test]
     fn local_api_fintech_preset_applies_base_score_override() {
         let config = apply_request_preset_for_api(
             veil_config::Config::default(),

--- a/docs/pr/PR-106-jp-local-api-preset.md
+++ b/docs/pr/PR-106-jp-local-api-preset.md
@@ -1,0 +1,56 @@
+# PR-106: JP Local API preset support
+
+## Why (Background)
+- #104 added JP preset support to the CLI path.
+- Local API scans still rejected implemented JP preset names, so UI/API scans could drift from CLI behavior.
+- The `logs-jp` preset must not silently pass with zero findings when the log RulePack is absent.
+
+## Summary
+- Resolve Local API `ScanRequest.preset` values as built-in JP preset base config layers.
+- Keep `CoreConfig.preset` out of scope; preset selection remains an API/CLI argument applied before repo/org/user overrides.
+- Add the smallest frontend path needed to pass preset selection into `/api/scan`.
+
+## Changes
+- Local API accepts `standard-jp`, `fintech-jp`, `gov-jp`, `si-vendor-jp`, and `logs-jp`.
+- Built-in preset layers are applied through `veil_config::apply_builtin_preset_as_base`.
+- `logs-jp` scans require a valid `rules/log` RulePack and return guidance when it is missing.
+- `logs-jp` required rule IDs are shared from `veil-config` to keep CLI and API behavior aligned.
+- Frontend scan requests include the selected preset when it is not the default.
+- Tests cover Local API preset score overrides and missing `logs-jp` RulePack guidance.
+
+## Non-goals (Not changed)
+- No `CoreConfig.preset` field.
+- No address/name validators.
+- No J-LIS MyNumber checksum implementation.
+- No large UI workflow redesign.
+- No new `severity` keys in JP preset TOML files; `base_score` remains the canonical score override.
+
+## Impact / Scope
+- CLI: no behavior change intended; shared `logs-jp` constants preserve the existing CLI guard.
+- Local API: JP preset names now resolve to effective config instead of being rejected.
+- UI: minimal preset selector added to the existing scan form.
+- Docs: this SOT records the code PR boundary after the design SOT sync in #105.
+- Rules: `logs-jp` continues to require the log RulePack.
+- Tests: API and existing CLI/config tests exercise the shared behavior.
+
+## Verification
+
+### Commands
+```bash
+cargo fmt --all --check
+python scripts/check_generated_schemas.py
+cargo test -p veil-pro
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+npm --prefix crates/veil-pro/frontend run build
+```
+
+### Notes / Evidence
+- `api::tests::local_api_fintech_preset_applies_base_score_override` verifies that `fintech-jp` base score overrides apply in the Local API scan path.
+- `api::tests::scan_logs_preset_without_rule_pack_returns_guidance` verifies that `logs-jp` returns explicit guidance when `rules/log` is absent.
+- Existing CLI preset tests pass after moving `LOGS_JP_REQUIRED_RULE_IDS` into `veil-config`.
+- `scripts/check_generated_schemas.py` passes; generated schema output remains stable.
+- `npm --prefix crates/veil-pro/frontend ci` was run locally before the frontend build to restore dependencies.
+
+## Rollback
+- Revert this PR as a unit to restore Local API preset rejection and remove the frontend preset selector while keeping the CLI preset support from #104.

--- a/docs/pr/PR-106-jp-local-api-preset.md
+++ b/docs/pr/PR-106-jp-local-api-preset.md
@@ -47,7 +47,7 @@ npm --prefix crates/veil-pro/frontend run build
 
 ### Notes / Evidence
 - `api::tests::local_api_fintech_preset_applies_base_score_override` verifies that `fintech-jp` base score overrides apply in the Local API scan path.
-- `api::tests::scan_logs_preset_without_rule_pack_returns_guidance` verifies that `logs-jp` returns explicit guidance when `rules/log` is absent.
+- `api::tests::local_api_logs_preset_without_rule_pack_returns_guidance` verifies that `logs-jp` returns explicit guidance when `rules/log` is absent.
 - Existing CLI preset tests pass after moving `LOGS_JP_REQUIRED_RULE_IDS` into `veil-config`.
 - `scripts/check_generated_schemas.py` passes; generated schema output remains stable.
 - `npm --prefix crates/veil-pro/frontend ci` was run locally before the frontend build to restore dependencies.

--- a/docs/pr/PR-106-jp-local-api-preset.md
+++ b/docs/pr/PR-106-jp-local-api-preset.md
@@ -47,7 +47,9 @@ npm --prefix crates/veil-pro/frontend run build
 
 ### Notes / Evidence
 - `api::tests::local_api_fintech_preset_applies_base_score_override` verifies that `fintech-jp` base score overrides apply in the Local API scan path.
+- `api::tests::local_api_preset_names_match_builtin_preset_ids` keeps the Local API enum mapped to the built-in preset ID set.
 - `api::tests::local_api_logs_preset_without_rule_pack_returns_guidance` verifies that `logs-jp` returns explicit guidance when `rules/log` is absent.
+- `presets::tests::logs_jp_required_rule_ids_are_present_in_preset_overrides` keeps `LOGS_JP_REQUIRED_RULE_IDS` aligned with the `logs-jp` preset override file.
 - Existing CLI preset tests pass after moving `LOGS_JP_REQUIRED_RULE_IDS` into `veil-config`.
 - `scripts/check_generated_schemas.py` passes; generated schema output remains stable.
 - `npm --prefix crates/veil-pro/frontend ci` was run locally before the frontend build to restore dependencies.


### PR DESCRIPTION
## Summary
- resolve Local API ScanRequest preset values as the same JP builtin preset base layer used by CLI
- require a valid rules/log RulePack for logs-jp scans, with guidance instead of a silent zero-finding success
- share logs-jp required rule IDs from veil-config so CLI and Local API do not drift
- add the minimal frontend preset selector and include preset in /api/scan requests

## SOT
- docs/pr/PR-106-jp-local-api-preset.md

## Tests
- cargo fmt --all --check
- python scripts/check_generated_schemas.py
- cargo test -p veil-pro
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- npm --prefix crates/veil-pro/frontend run build

## Notes
- Ran npm --prefix crates/veil-pro/frontend ci to restore local frontend dependencies before build; node_modules and dist remain ignored.