### PR TITLE
Wire JP PII contract acceptance gate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,3 +201,34 @@ jobs:
 
       - name: Test Integration (Other)
         run: cargo test --workspace --tests --exclude veil-guardian --verbose
+
+  contract-acceptance:
+    name: contract-acceptance
+    runs-on: ubuntu-latest
+    needs: [stable]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.92.0
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: crates/veil-pro/frontend/package-lock.json
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Python schema dependencies
+        run: python -m pip install --disable-pip-version-check PyYAML==6.0.2
+      - name: Install frontend dependencies
+        run: npm --prefix crates/veil-pro/frontend ci
+      - name: Run contract acceptance
+        run: python scripts/check_contract_acceptance.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,10 @@ jobs:
     name: contract-acceptance
     runs-on: ubuntu-latest
     needs: [stable]
+    env:
+      CARGO_NET_RETRY: "10"
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      CARGO_HTTP_TIMEOUT: "600"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -21,7 +21,7 @@
 - [x] `RunMetaResponse` を full RunMetaV1 として実装
 - [x] `coverageComplete` を API/report/run_meta に追加
 - [x] `json-schema.report.json` に `$defs.SafeFindingApiV1` を埋め込む
-- [ ] `14_bulk_implementation_safety.md` のAcceptance GateをCIへ追加
+- [x] `14_bulk_implementation_safety.md` のAcceptance GateをCIへ追加
 
 ## Phase 1: JP-PII Engine Hardening
 
@@ -39,13 +39,13 @@ PR分割:
 
 ## Phase 2: Zero-Config & Preset UX
 
-- [ ] `CoreConfig.preset` 追加（急がない。#105時点ではCLI引数のbase layer適用を正本とし、Local APIは後続PRで対応する）
+- [ ] `CoreConfig.preset` 追加（急がない。#106時点ではCLI/Local API引数のbase layer適用を正本とする）
 - [x] `veil init --preset` 実装
 - [x] `veil scan --preset` 実装
 - [ ] wizard推論ロジック
 - [ ] docs/README更新
 - [x] `veil config dump --preset` 実装
-- [ ] Local API / UI の preset対応
+- [x] Local API / UI の preset対応（#106: Local API scan preset解決 + 最小UI selector。大きなUI workflow改修はPhase 5）
 
 ## Phase 3: Interactive CLI
 

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2504,7 +2504,7 @@ PR-0では以下を必須testにする。
 - [x] `RunMetaResponse` を full RunMetaV1 として実装
 - [x] `coverageComplete` を API/report/run_meta に追加
 - [x] `json-schema.report.json` に `$defs.SafeFindingApiV1` を埋め込む
-- [ ] `14_bulk_implementation_safety.md` のAcceptance GateをCIへ追加
+- [x] `14_bulk_implementation_safety.md` のAcceptance GateをCIへ追加
 
 ## Phase 1: JP-PII Engine Hardening
 
@@ -2522,13 +2522,13 @@ PR分割:
 
 ## Phase 2: Zero-Config & Preset UX
 
-- [ ] `CoreConfig.preset` 追加（急がない。#105時点ではCLI引数のbase layer適用を正本とし、Local APIは後続PRで対応する）
+- [ ] `CoreConfig.preset` 追加（急がない。#106時点ではCLI/Local API引数のbase layer適用を正本とする）
 - [x] `veil init --preset` 実装
 - [x] `veil scan --preset` 実装
 - [ ] wizard推論ロジック
 - [ ] docs/README更新
 - [x] `veil config dump --preset` 実装
-- [ ] Local API / UI の preset対応
+- [x] Local API / UI の preset対応（#106: Local API scan preset解決 + 最小UI selector。大きなUI workflow改修はPhase 5）
 
 ## Phase 3: Interactive CLI
 

--- a/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
+++ b/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
@@ -6,7 +6,7 @@
 - [x] DTOに `serde`, `schemars`, `utoipa` deriveを付ける。
 - [x] `crates/veil-pro/src/bin/export_local_api_schema.rs` を追加し、OpenAPI / JSON Schema を repo root `schemas/` へ生成する。
 - [x] `scripts/check_generated_schemas.py` を追加し、生成schemaとtracked schemaの差分を検出可能にする。
-- [ ] `scripts/check_generated_schemas.py` または `scripts/check_contract_acceptance.py` をCI workflowへ配線する。
+- [x] `scripts/check_generated_schemas.py` または `scripts/check_contract_acceptance.py` をCI workflowへ配線する。
 - [x] `schemas/json-schema.report.json` を生成物として追加し、`$defs.SafeFindingApiV1` を内包する。
 - [x] `schemas/json-schema.run-meta.json` から `artifacts.runMeta` を排除する。
 - [x] `ScanRequest.paths` missing/empty -> `["."]` 正規化test。
@@ -53,12 +53,12 @@
 - [x] `logs-jp` initで `rules/log` を生成。
 - [x] `--ci` と `--preset` / `--profile` / `--wizard` の同時指定を拒否。
 
-## Next: Local API / UI preset support
+## #106 Local API / UI preset support（merge済み）
 
-- [ ] Local API scanで `PresetName` を builtin preset configへ解決する。
-- [ ] `logs-jp` scanではCLIと同じく `rules/log` RulePackを必須にする。
+- [x] Local API scanで `PresetName` を builtin preset configへ解決する。
+- [x] `logs-jp` scanではCLIと同じく `rules/log` RulePackを必須にする。
 - [ ] OpenAPI generated schemaをUI clientへ反映。
-- [ ] UI scan requestでpresetを渡せる最小導線を確認する。
+- [x] UI scan requestでpresetを渡せる最小導線を確認する。
 - [ ] `includeSuppressed` UI toggle
 - [ ] limit reached / coverageComplete UI表示
 

--- a/docs/pr/PR-TBD-jp-pii-contract-acceptance-ci.md
+++ b/docs/pr/PR-TBD-jp-pii-contract-acceptance-ci.md
@@ -1,0 +1,38 @@
+# PR-TBD: JP PII contract acceptance CI gate
+
+## Why (Background)
+- #106 merged Local API and minimal UI support for JP preset selection.
+- The JP PII SOT still marked the contract acceptance gate and Local API/UI preset support as unfinished.
+- Previous review feedback correctly required CI enforcement before marking schema drift / acceptance gates complete.
+
+## Summary
+- Add a `contract-acceptance` CI job that invokes `python scripts/check_contract_acceptance.py`.
+- Install Rust, Node, frontend dependencies, Python 3.12, and pinned `PyYAML` so the CI gate is reproducible.
+- Sync JP PII roadmap/task breakdown text after #106 without marking unfinished UI completion work as done.
+
+## Changes
+- `.github/workflows/ci.yml` now runs the contract acceptance wrapper after the stable job succeeds.
+- `13_implementation_roadmap.md` and `DETAIL_DESIGN.md` now mark the acceptance gate and #106 preset path complete.
+- `implementation/task_breakdown.md` now marks Local API preset resolution, `logs-jp` RulePack enforcement, and the minimal UI request path complete.
+- Generated UI client alignment, `includeSuppressed` UI, and `coverageComplete` UI remain unchecked.
+
+## Non-goals (Not changed)
+- No `CoreConfig.preset` field.
+- No address/name validators.
+- No J-LIS MyNumber checksum implementation.
+- No score calibration.
+- No large UI workflow redesign.
+
+## Verification
+
+### Commands
+```bash
+cargo fmt --all --check
+python scripts/check_generated_schemas.py
+cargo run -p veil-cli -- verify tests/fixtures/evidence/golden.zip --require-complete
+npm --prefix crates/veil-pro/frontend run build
+python scripts/check_contract_acceptance.py
+```
+
+## Rollback
+- Revert this PR as a unit to remove the CI gate and restore the SOT checkboxes to their pre-#106 follow-up state.


### PR DESCRIPTION
# PR-TBD: JP PII contract acceptance CI gate

## Why (Background)
- #106 merged Local API and minimal UI support for JP preset selection.
- The JP PII SOT still marked the contract acceptance gate and Local API/UI preset support as unfinished.
- Previous review feedback correctly required CI enforcement before marking schema drift / acceptance gates complete.

## Summary
- Add a `contract-acceptance` CI job that invokes `python scripts/check_contract_acceptance.py`.
- Install Rust, Node, frontend dependencies, Python 3.12, and pinned `PyYAML` so the CI gate is reproducible.
- Sync JP PII roadmap/task breakdown text after #106 without marking unfinished UI completion work as done.

## Changes
- `.github/workflows/ci.yml` now runs the contract acceptance wrapper after the stable job succeeds.
- `13_implementation_roadmap.md` and `DETAIL_DESIGN.md` now mark the acceptance gate and #106 preset path complete.
- `implementation/task_breakdown.md` now marks Local API preset resolution, `logs-jp` RulePack enforcement, and the minimal UI request path complete.
- Generated UI client alignment, `includeSuppressed` UI, and `coverageComplete` UI remain unchecked.

## Non-goals (Not changed)
- No `CoreConfig.preset` field.
- No address/name validators.
- No J-LIS MyNumber checksum implementation.
- No score calibration.
- No large UI workflow redesign.

## Verification

### Commands
```bash
cargo fmt --all --check
python scripts/check_generated_schemas.py
cargo run -p veil-cli -- verify tests/fixtures/evidence/golden.zip --require-complete
npm --prefix crates/veil-pro/frontend run build
python scripts/check_contract_acceptance.py
```

## Rollback
- Revert this PR as a unit to remove the CI gate and restore the SOT checkboxes to their pre-#106 follow-up state.
