### PR TITLE
Add PR SOT template helper

### DIFF
--- a/crates/veil-cli/src/cli.rs
+++ b/crates/veil-cli/src/cli.rs
@@ -379,7 +379,11 @@ pub enum SotCommand {
 
 #[derive(Args, Debug)]
 pub struct SotNewArgs {
-    /// Target release version (e.g. v0.19.0). If not specified, inferred from branch.
+    /// Pull Request number. If omitted, creates a PR-TBD SOT file.
+    #[arg(long)]
+    pub pr: Option<u32>,
+
+    /// Target release version (e.g. v0.19.0). If omitted, a slug-only filename is used.
     #[arg(long)]
     pub release: Option<String>,
 
@@ -398,6 +402,14 @@ pub struct SotNewArgs {
     /// Optional title overlap
     #[arg(long)]
     pub title: Option<String>,
+
+    /// SOT status
+    #[arg(long, default_value = "Draft")]
+    pub status: String,
+
+    /// Creation date to write into front matter. Defaults to TBD for deterministic output.
+    #[arg(long)]
+    pub date: Option<String>,
 
     /// Dry run (do not write files)
     #[arg(long)]

--- a/crates/veil-cli/src/commands/sot.rs
+++ b/crates/veil-cli/src/commands/sot.rs
@@ -1,6 +1,5 @@
 use crate::cli::{SotCommand, SotNewArgs, SotRenameArgs};
 use anyhow::{anyhow, Context, Result};
-use chrono::Local;
 use colored::Colorize;
 use regex::Regex;
 use std::env;
@@ -15,52 +14,71 @@ pub fn run(cmd: &SotCommand) -> Result<bool> {
 }
 
 fn run_new(args: &SotNewArgs) -> Result<bool> {
-    // 1. Determine release
-    let release = match &args.release {
-        Some(r) => r.clone(),
-        None => infer_release()?,
-    };
-
-    // 2. Prepare other vars
+    // 1. Prepare vars
     let epic = &args.epic;
     let slug = args.slug.as_deref().unwrap_or("");
     let sanitized_slug = sanitize_slug(slug);
+    let release = match &args.release {
+        Some(r) => Some(r.clone()),
+        None if sanitized_slug.is_empty() => infer_release().ok(),
+        None => None,
+    };
 
-    // 3. Filename
-    // slugなし: docs/pr/PR-TBD-<release>-epic-<epic>.md
-    // slugあり: docs/pr/PR-TBD-<release>-epic-<epic>-<slug>.md
-    let filename = if sanitized_slug.is_empty() {
-        format!("PR-TBD-{}-epic-{}.md", release, epic.to_lowercase())
-    } else {
-        format!(
-            "PR-TBD-{}-epic-{}-{}.md",
+    if release.is_none() && sanitized_slug.is_empty() {
+        return Err(anyhow!(
+            "Please specify --slug for a PR-TBD-<slug>.md SOT file, or --release for a release/epic SOT file."
+        ));
+    }
+
+    // 2. Filename
+    // slug-only: docs/pr/PR-TBD-<slug>.md or docs/pr/PR-<number>-<slug>.md
+    // release: docs/pr/PR-TBD-<release>-epic-<epic>[-<slug>].md
+    let pr_label = match args.pr {
+        Some(pr) => format!("PR-{}", pr),
+        None => "PR-TBD".to_string(),
+    };
+    let filename = match &release {
+        Some(release) if sanitized_slug.is_empty() => {
+            format!("{}-{}-epic-{}.md", pr_label, release, epic.to_lowercase())
+        }
+        Some(release) => format!(
+            "{}-{}-epic-{}-{}.md",
+            pr_label,
             release,
             epic.to_lowercase(),
             sanitized_slug
-        )
+        ),
+        None => format!("{}-{}.md", pr_label, sanitized_slug),
     };
 
     let out_dir = &args.out;
     let out_path = out_dir.join(&filename);
 
-    // 4. Git info
+    // 3. Git info
     let (branch, commit) =
         get_git_info().unwrap_or_else(|_| ("unknown".to_string(), "unknown".to_string()));
-    let created_at = Local::now().format("%Y-%m-%d").to_string();
+    let created_at = args.date.as_deref().unwrap_or("TBD");
     let title = args.title.as_deref().unwrap_or("TBD");
+    let pr = args
+        .pr
+        .map(|pr| pr.to_string())
+        .unwrap_or_else(|| "TBD".to_string());
+    let release = release.as_deref().unwrap_or("TBD");
 
-    // 5. Template replacement
+    // 4. Template replacement
     // We use include_str! relative to this file location
     let template = include_str!("../templates/sot/sot_v1.md");
     let content = template
-        .replace("{{release}}", &release)
+        .replace("{{release}}", release)
         .replace("{{epic}}", epic)
-        .replace("{{created_at}}", &created_at)
+        .replace("{{pr}}", &pr)
+        .replace("{{status}}", &args.status)
+        .replace("{{created_at}}", created_at)
         .replace("{{branch}}", &branch)
         .replace("{{commit}}", &commit)
         .replace("{{title}}", title);
 
-    // 6. Action
+    // 5. Action
     if args.dry_run {
         println!("Dry run: would create {}", out_path.display());
         println!();
@@ -89,10 +107,7 @@ fn run_new(args: &SotNewArgs) -> Result<bool> {
         println!();
         println!("Next:");
         println!("git add {}", out_path.display());
-        println!(
-            "git commit -m \"docs: add SOT ({} Epic {})\"",
-            release, epic
-        );
+        println!("git commit -m \"docs: add PR SOT ({})\"", filename);
     }
 
     Ok(false)

--- a/crates/veil-cli/src/templates/sot/sot_v1.md
+++ b/crates/veil-cli/src/templates/sot/sot_v1.md
@@ -1,40 +1,30 @@
 ---
 release: {{release}}
 epic: {{epic}}
-pr: TBD
-status: draft
+pr: {{pr}}
+status: {{status}}
 created_at: {{created_at}}
 branch: {{branch}}
 commit: {{commit}}
 title: {{title}}
 ---
 
-## Overview
-(1-3 lines)
+## SOT
+- Title: {{title}}
+- Status: {{status}}
+- PR: {{pr}}
 
-## Goals
-- [ ] ...
-
-## Non-Goals
-- [ ] ...
-
-## Design
-### CLI
-- Command: `veil sot new ...`
-- Output path: `docs/pr/...`
-
-### Files / Formats
-- ...
+## What
+- [ ] Describe the concrete change.
 
 ## Verification
-- [ ] `cargo test -p veil-cli`
-- [ ] Manual: `veil sot new --dry-run ...`
+- [ ] Add exact commands and results.
 
-## Risks / Rollback
-- Risks:
-- Rollback:
+## Evidence
+- [ ] Link logs, screenshots, fixtures, or CI runs.
 
-## Audit Notes
-- Evidence:
-  - Generated SOT file under docs/pr
-  - CI logs referencing SOT path
+## Non-goals
+- [ ] Name what this PR intentionally leaves alone.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.

--- a/crates/veil-cli/tests/sot_new_test.rs
+++ b/crates/veil-cli/tests/sot_new_test.rs
@@ -28,8 +28,86 @@ fn test_sot_new_success() -> Result<(), Box<dyn std::error::Error>> {
     let content = fs::read_to_string(expected_file)?;
     assert!(content.contains("release: v0.19.0"));
     assert!(content.contains("epic: A"));
+    assert!(content.contains("pr: TBD"));
+    assert!(content.contains("status: Draft"));
+    assert!(content.contains("created_at: TBD"));
     assert!(content.contains("title: TBD"));
     assert!(content.contains("---"));
+
+    Ok(())
+}
+
+#[test]
+fn test_sot_new_slug_only_success() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempdir()?;
+    let out_dir = temp.path().join("docs/pr");
+
+    let mut cmd = cargo_bin_cmd!("veil");
+
+    cmd.arg("sot")
+        .arg("new")
+        .arg("--slug")
+        .arg("SOT Template Helper")
+        .arg("--title")
+        .arg("Add PR SOT template helper")
+        .arg("--status")
+        .arg("Ready")
+        .arg("--date")
+        .arg("2026-07-06")
+        .arg("--out")
+        .arg(out_dir.as_os_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created SOT:"))
+        .stdout(predicate::str::contains("PR-TBD-sot-template-helper.md"));
+
+    let expected_file = out_dir.join("PR-TBD-sot-template-helper.md");
+    assert!(expected_file.exists());
+
+    let content = fs::read_to_string(expected_file)?;
+    assert!(content.contains("release: TBD"));
+    assert!(content.contains("epic: A"));
+    assert!(content.contains("pr: TBD"));
+    assert!(content.contains("status: Ready"));
+    assert!(content.contains("created_at: 2026-07-06"));
+    assert!(content.contains("title: Add PR SOT template helper"));
+    assert!(content.contains("## SOT"));
+    assert!(content.contains("## What"));
+    assert!(content.contains("## Verification"));
+    assert!(content.contains("## Evidence"));
+    assert!(content.contains("## Non-goals"));
+    assert!(content.contains("## Rollback"));
+
+    Ok(())
+}
+
+#[test]
+fn test_sot_new_pr_numbered_slug_success() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempdir()?;
+    let out_dir = temp.path().join("docs/pr");
+
+    let mut cmd = cargo_bin_cmd!("veil");
+
+    cmd.arg("sot")
+        .arg("new")
+        .arg("--pr")
+        .arg("123")
+        .arg("--slug")
+        .arg("sample")
+        .arg("--title")
+        .arg("Sample")
+        .arg("--out")
+        .arg(out_dir.as_os_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PR-123-sample.md"));
+
+    let expected_file = out_dir.join("PR-123-sample.md");
+    assert!(expected_file.exists());
+
+    let content = fs::read_to_string(expected_file)?;
+    assert!(content.contains("pr: 123"));
+    assert!(content.contains("- PR: 123"));
 
     Ok(())
 }
@@ -58,6 +136,7 @@ fn test_sot_new_slug_dry_run() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::contains("Dry run: would create"))
         .stdout(predicate::str::contains("title: My Title"))
+        .stdout(predicate::str::contains("created_at: TBD"))
         .stdout(predicate::str::contains(
             "docs/pr/PR-TBD-v0.19.0-epic-c-audit-log.md",
         ));

--- a/docs/pr/PR-111-sot-template-helper.md
+++ b/docs/pr/PR-111-sot-template-helper.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 111
 status: Draft
 created_at: TBD
 branch: feat/sot-template-helper
@@ -12,7 +12,7 @@ title: Add PR SOT template helper
 ## SOT
 - Title: Add PR SOT template helper
 - Status: Draft
-- PR: TBD
+- PR: 111
 
 ## What
 - Add `veil sot new --slug <slug>` support for slug-only SOT names such as `docs/pr/PR-TBD-sot-template-helper.md`.
@@ -34,7 +34,7 @@ title: Add PR SOT template helper
 - `cargo test -p veil-cli sot_new -- --nocapture` passed with 5 `sot_new_test` tests.
 - `cargo test -p veil-cli sot_rename -- --nocapture` passed with 3 `sot_rename_test` tests.
 - The dry-run command printed the `docs/pr/PR-999-sample.md` content to stdout without writing a file.
-- The generated SOT file is this file: `docs/pr/PR-TBD-sot-template-helper.md`.
+- The generated SOT file was renamed to this file after PR creation: `docs/pr/PR-111-sot-template-helper.md`.
 
 ## Non-goals
 - Do not weaken or bypass `.github/workflows/pr_sot_guard.yml`.

--- a/docs/pr/PR-TBD-sot-template-helper.md
+++ b/docs/pr/PR-TBD-sot-template-helper.md
@@ -1,0 +1,45 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/sot-template-helper
+commit: 7f9ca1de4942f9ceebd11154c5cc5e08a2ec9990
+title: Add PR SOT template helper
+---
+
+## SOT
+- Title: Add PR SOT template helper
+- Status: Draft
+- PR: TBD
+
+## What
+- Add `veil sot new --slug <slug>` support for slug-only SOT names such as `docs/pr/PR-TBD-sot-template-helper.md`.
+- Add `veil sot new --pr <number>` support for direct `PR-<number>-<slug>.md` creation.
+- Add `--status` and `--date`; default `created_at` to `TBD` so generation does not depend on the current clock.
+- Align the built-in SOT template and `docs/pr/sot_template.md` with the standard SOT / What / Verification / Evidence / Non-goals / Rollback sections.
+- Update `docs/pr/README.md` to document the helper instead of the stale manual-only workflow.
+
+## Verification
+- [x] `cargo fmt --all --check`
+- [x] `git diff --check`
+- [x] `cargo test -p veil-cli sot_new -- --nocapture`
+- [x] `cargo test -p veil-cli sot_rename -- --nocapture`
+- [x] `cargo run -p veil-cli -- sot new --slug sot-template-helper --title "Add PR SOT template helper"`
+- [x] `cargo run -p veil-cli -- sot new --pr 999 --slug sample --title "Sample" --dry-run`
+- [x] `cargo clippy -p veil-cli --all-targets --all-features -- -D warnings`
+
+## Evidence
+- `cargo test -p veil-cli sot_new -- --nocapture` passed with 5 `sot_new_test` tests.
+- `cargo test -p veil-cli sot_rename -- --nocapture` passed with 3 `sot_rename_test` tests.
+- The dry-run command printed the `docs/pr/PR-999-sample.md` content to stdout without writing a file.
+- The generated SOT file is this file: `docs/pr/PR-TBD-sot-template-helper.md`.
+
+## Non-goals
+- Do not weaken or bypass `.github/workflows/pr_sot_guard.yml`.
+- Do not introduce a separate SOT script while the existing `veil sot` command already owns this workflow.
+- Do not touch JP PII address validator wiring; that remains the next small PR.
+
+## Rollback
+- Revert this PR as a unit to restore the previous `veil sot new` behavior and docs.

--- a/docs/pr/README.md
+++ b/docs/pr/README.md
@@ -7,37 +7,76 @@ A SOT document is the persistent record of the PR's intent, changes, and verific
 
 Recommended (before PR number is known):
 
+- `docs/pr/PR-TBD-<slug>.md`
+  - e.g. `docs/pr/PR-TBD-sot-template-helper.md`
 - `docs/pr/PR-TBD-<release>-epic-<epic>[-<slug>].md`
   - e.g. `docs/pr/PR-TBD-v0.19.0-epic-a.md`
   - e.g. `docs/pr/PR-TBD-v0.19.0-epic-b-sot-ux.md`
 
 Optional (after PR number is assigned):
 
+- rename to `docs/pr/PR-<pr>-<slug>.md`
+  - e.g. `docs/pr/PR-123-sot-template-helper.md`
 - rename to `docs/pr/PR-<pr>-<release>-epic-<epic>[-<slug>].md`
   - e.g. `docs/pr/PR-123-v0.19.0-epic-b-sot-ux.md`
 
 The key is that the file exists *before* you open the PR, so the PR body can link to it reliably.
 
-## Workflow (Manual)
+## Workflow
 
 1. Create a new SOT file:
-   - `docs/pr/PR-TBD-<release>-epic-<epic>[-<slug>].md`
-   - e.g. `cp docs/pr/sot_template.md docs/pr/PR-TBD-...`
+   ```bash
+   cargo run -p veil-cli -- sot new \
+     --slug sot-template-helper \
+     --title "Add PR SOT template helper"
+   ```
 2. Fill standard sections:
-   - SOT / What / Verification / Evidence
+   - SOT / What / Verification / Evidence / Non-goals / Rollback
 3. Copy-paste the SOT filename into your PR description:
    ```md
    ### SOT
    - docs/pr/PR-TBD-...
    ```
-4. Keep the SOT updated as the PR evolves.
+4. After the PR number is assigned, rename the file if desired:
+   ```bash
+   cargo run -p veil-cli -- sot rename --pr 123 --path docs/pr/PR-TBD-sot-template-helper.md
+   ```
+5. Keep the SOT updated as the PR evolves.
+
+## Useful Commands
+
+Dry-run without writing a file:
+
+```bash
+cargo run -p veil-cli -- sot new \
+  --slug sample \
+  --title "Sample" \
+  --dry-run
+```
+
+Create a PR-numbered SOT directly:
+
+```bash
+cargo run -p veil-cli -- sot new \
+  --pr 123 \
+  --slug sample \
+  --title "Sample"
+```
+
+Create a release/epic style SOT:
+
+```bash
+cargo run -p veil-cli -- sot new \
+  --release v0.19.0 \
+  --epic A \
+  --slug audit-log \
+  --title "Audit log updates"
+```
+
+`sot new` does not insert the current date by default. Use `--date YYYY-MM-DD` when the date should be part of the record.
 
 ## Why SOT?
 
-- Consistent naming + metadata via manual creation.
+- Consistent naming + metadata via a deterministic helper.
 - Persistent record that survives squash merges.
 - Single place for complex verification logs and evidence.
-
-> [!NOTE]
-> **Manual SOT Creation**
-> Since `veil sot new` is removed, please use `cp docs/pr/sot_template.md ...` or create the file manually.

--- a/docs/pr/sot_template.md
+++ b/docs/pr/sot_template.md
@@ -1,38 +1,32 @@
+---
+release: TBD
+epic: TBD
+pr: TBD
+status: Draft
+created_at: TBD
+branch: TBD
+commit: TBD
+title: TBD
+---
+
 # SOT Template
-# PR-TBD-<release>-epic-<epic>[-<slug>]: [Title]
 
-> This file is kept for historical reference.
-> For new work, copy this to `docs/pr/PR-<NUMBER>-<slug>.md`.
+## SOT
+- Title: TBD
+- Status: Draft
+- PR: TBD
 
-## Why (Background)
-- Why now? What pain does this solve?
-
-## Summary
-- 2-3 lines.
-
-## Changes
-- [ ]
-
-## Non-goals (Not changed)
-- [ ]
-
-## Impact / Scope
-- CLI: [ ]
-- CI: [ ]
-- Docs: [ ]
-- Rules: [ ]
-- Tests: [ ]
+## What
+- [ ] Describe the concrete change.
 
 ## Verification
+- [ ] Add exact commands and results.
 
-### Commands
-```bash
-# example
-cargo test --workspace
-```
+## Evidence
+- [ ] Link logs, screenshots, fixtures, or CI runs.
 
-### Notes / Evidence
-- [ ]
+## Non-goals
+- [ ] Name what this PR intentionally leaves alone.
 
 ## Rollback
-- How to revert safely (1-2 lines).
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## What
- Add deterministic SOT creation paths to `veil sot new`.
- Support slug-only `PR-TBD-<slug>.md` and direct `PR-<number>-<slug>.md` output.
- Align the generated SOT templates and docs with the current SOT Guard workflow.

## Why
SOT Guard should stay strict, but creating a PR SOT by hand caused avoidable friction. This keeps the guard intact while making the expected file easy to create and verify.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p veil-cli sot_new -- --nocapture`
- `cargo test -p veil-cli sot_rename -- --nocapture`

## SOT
- docs/pr/PR-111-sot-template-helper.md