### PR TITLE
Tune JP PII negative test context scoring

### DIFF
--- a/crates/veil-core/src/scoring.rs
+++ b/crates/veil-core/src/scoring.rs
@@ -22,6 +22,12 @@ impl Default for ScoreParams {
                 "sample".to_string(),
                 "dummy".to_string(),
                 "mock".to_string(),
+                "sandbox".to_string(),
+                "テスト".to_string(),
+                "サンプル".to_string(),
+                "ダミー".to_string(),
+                "モック".to_string(),
+                "サンドボックス".to_string(),
             ],
             prod_words: vec![
                 "prod".to_string(),
@@ -187,6 +193,18 @@ mod tests {
         // Test context
         finding.context_before = vec!["// this is a test case".to_string()];
         assert_eq!(calculate_score(&rule, &finding, &params), 50); // 60 - 10
+
+        for context in [
+            "// sandbox fixture",
+            "// これはテスト用データです",
+            "// サンプルCSV",
+            "// ダミー個人情報",
+            "// モックAPI",
+            "// サンドボックス環境",
+        ] {
+            finding.context_before = vec![context.to_string()];
+            assert_eq!(calculate_score(&rule, &finding, &params), 50);
+        }
 
         // Prod context
         finding.context_before = vec!["// production config".to_string()];

--- a/docs/pr/PR-113-jp-pii-score-tuning.md
+++ b/docs/pr/PR-113-jp-pii-score-tuning.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 113
 status: Draft
 created_at: TBD
 branch: feat/jp-pii-score-tuning
@@ -12,7 +12,7 @@ title: Tune JP PII negative test context scoring
 ## SOT
 - Title: Tune JP PII negative test context scoring
 - Status: Draft
-- PR: TBD
+- PR: 113
 
 ## What
 - [x] Add English `sandbox` and Japanese test-data context words to the default score-dampening list.

--- a/docs/pr/PR-TBD-jp-pii-score-tuning.md
+++ b/docs/pr/PR-TBD-jp-pii-score-tuning.md
@@ -1,0 +1,37 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/jp-pii-score-tuning
+commit: d60e912dd641f040cf6abab7cd7cfa02d53e3cf1
+title: Tune JP PII negative test context scoring
+---
+
+## SOT
+- Title: Tune JP PII negative test context scoring
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add English `sandbox` and Japanese test-data context words to the default score-dampening list.
+- [x] Cover the new context words in the scoring unit test so test/sample/dummy/mock/sandbox contexts remain deterministic.
+
+## Verification
+- [x] `cargo fmt --all --check` — passed.
+- [x] `git diff --check` — passed.
+- [x] `cargo test -p veil-core test_context_modifiers -- --nocapture` — passed.
+- [x] `cargo test -p veil-core jp_pii -- --nocapture` — passed.
+- [x] `cargo clippy -p veil-core --all-targets --all-features -- -D warnings` — passed.
+
+## Evidence
+- [x] Local unit and JP PII fixture tests verify the score-context behavior and existing Japanese PII detection fixtures.
+
+## Non-goals
+- [x] Do not rebalance JP PII rule base scores or grade thresholds.
+- [x] Do not add broad Japanese context words such as `例`, because they are too likely to dampen real findings.
+- [x] Do not change masking, validators, or rule matching behavior.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- Add `sandbox` and Japanese test-data context words to the default score dampening list.
- Cover the new context words in the scoring unit test.

## Why
JP PII scoring already dampened English test/example/sample/dummy/mock contexts, while the enterprise JP PII design also calls out sandbox/example/dummy context dampening. This PR makes Japanese test-data contexts behave the same way without changing matching, masking, validators, grade thresholds, or rule base scores.

## SOT
- docs/pr/PR-113-jp-pii-score-tuning.md

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p veil-core test_context_modifiers -- --nocapture`
- `cargo test -p veil-core jp_pii -- --nocapture`
- `cargo clippy -p veil-core --all-targets --all-features -- -D warnings`