### PR TITLE
Sync JP PII implementation status docs

### DIFF
--- a/docs/design/enterprise_jp_pii/04_jp_pii_detection_strategy.md
+++ b/docs/design/enterprise_jp_pii/04_jp_pii_detection_strategy.md
@@ -198,6 +198,7 @@ Fail条件は `score` を正本にする。`--fail-on-severity High` は `score 
 - [x] order number / version number / dummy-test-example / fullwidth non-JP secret / known test card negative fixturesを追加。
 - [x] `standard-jp`, `fintech-jp`, `gov-jp`, `si-vendor-jp`, `logs-jp` preset override resolverを追加。
 - [x] `veil scan --preset`, `veil init --preset`, `veil config dump --preset` CLI UXを追加。
-- [ ] Address validatorを実装する。現状の `pii.jp.address.prefecture_heuristic` はvalidatorなしのヒューリスティックであり、実装済みvalidatorとは扱わない。
+- [x] Address validatorを実装し、`pii.jp.address.prefecture_heuristic` に `jp_address_prefecture_city_block` validatorを配線する。
+- [x] negative context score dampeningに `sandbox` と日本語テストデータ文脈を追加する。
 - [ ] Name validatorを実装する。現状の `pii.person.name.keyword` はラベル付きヒューリスティックであり、実装済みvalidatorとは扱わない。
 - [ ] J-LIS MyNumberチェックデジットを feature flag `jp_mynumber_checksum` として後続実装する。

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -27,15 +27,17 @@
 
 - [x] `jp_normalize` 実装
 - [x] span mapping導入
-- [x] MyNumber validator / Luhn validator / mobile validator
+- [x] MyNumber validator / Luhn validator / mobile validator / address validator
 - [x] `standard-jp`, `fintech-jp`, `gov-jp`, `si-vendor-jp`, `logs-jp` presets追加
 - [x] Positive/Negative fixtures追加
-- [ ] score調整
+- [x] score調整（negative context dampeningをJPテストデータ文脈へ拡張）
 
 PR分割:
 1. #101 `feat(core): add jp normalization and span mapping`
 2. #102 `test(jp-pii): add validators and fixtures`
 3. #103 `feat(config): add JP preset override resolver`
+4. #112 `Wire JP address validator into address rule`
+5. #113 `Tune JP PII negative test context scoring`
 
 ## Phase 2: Zero-Config & Preset UX
 

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -1095,7 +1095,8 @@ Fail条件は `score` を正本にする。`--fail-on-severity High` は `score 
 - [x] order number / version number / dummy-test-example / fullwidth non-JP secret / known test card negative fixturesを追加。
 - [x] `standard-jp`, `fintech-jp`, `gov-jp`, `si-vendor-jp`, `logs-jp` preset override resolverを追加。
 - [x] `veil scan --preset`, `veil init --preset`, `veil config dump --preset` CLI UXを追加。
-- [ ] Address validatorを実装する。現状の `pii.jp.address.prefecture_heuristic` はvalidatorなしのヒューリスティックであり、実装済みvalidatorとは扱わない。
+- [x] Address validatorを実装し、`pii.jp.address.prefecture_heuristic` に `jp_address_prefecture_city_block` validatorを配線する。
+- [x] negative context score dampeningに `sandbox` と日本語テストデータ文脈を追加する。
 - [ ] Name validatorを実装する。現状の `pii.person.name.keyword` はラベル付きヒューリスティックであり、実装済みvalidatorとは扱わない。
 - [ ] J-LIS MyNumberチェックデジットを feature flag `jp_mynumber_checksum` として後続実装する。
 
@@ -2510,15 +2511,17 @@ PR-0では以下を必須testにする。
 
 - [x] `jp_normalize` 実装
 - [x] span mapping導入
-- [x] MyNumber validator / Luhn validator / mobile validator
+- [x] MyNumber validator / Luhn validator / mobile validator / address validator
 - [x] `standard-jp`, `fintech-jp`, `gov-jp`, `si-vendor-jp`, `logs-jp` presets追加
 - [x] Positive/Negative fixtures追加
-- [ ] score調整
+- [x] score調整（negative context dampeningをJPテストデータ文脈へ拡張）
 
 PR分割:
 1. #101 `feat(core): add jp normalization and span mapping`
 2. #102 `test(jp-pii): add validators and fixtures`
 3. #103 `feat(config): add JP preset override resolver`
+4. #112 `Wire JP address validator into address rule`
+5. #113 `Tune JP PII negative test context scoring`
 
 ## Phase 2: Zero-Config & Preset UX
 

--- a/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
+++ b/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
@@ -34,7 +34,7 @@
 - [x] 互換読み込みwarning
 - [x] MyNumber validator / Luhn validator / mobile validator
 - [x] Positive/Negative fixtures追加
-- [ ] Address validatorは未実装。現状はvalidatorなしの住所ヒューリスティックのみ。
+- [x] Address validatorは #112 で実装・配線済み。`pii.jp.address.prefecture_heuristic` は `jp_address_prefecture_city_block` validatorを使う。
 - [ ] Name validatorは未実装。現状はvalidatorなしのラベル付き氏名ヒューリスティックのみ。
 - [ ] J-LIS MyNumberチェックデジットは feature flag `jp_mynumber_checksum` の後続実装。
 
@@ -61,6 +61,18 @@
 - [x] UI scan requestでpresetを渡せる最小導線を確認する。
 - [ ] `includeSuppressed` UI toggle
 - [ ] limit reached / coverageComplete UI表示
+
+## #112 JP address validator wiring（merge済み）
+
+- [x] `pii.jp.address.prefecture_heuristic` に `jp_address_prefecture_city_block` validatorを配線。
+- [x] 全角住所positive fixtureと住所ラベルのみnegative fixtureを追加。
+- [x] Built-in ruleでaddress validatorが解決されることをtestで固定。
+
+## #113 JP PII score context tuning（merge済み）
+
+- [x] `sandbox` と日本語のテスト/サンプル/ダミー/モック/サンドボックス文脈でscore減衰する。
+- [x] score context modifierの単体テストを追加。
+- [x] JP PII fixtureが既存検知挙動を維持することを確認。
 
 ## Later: LSP
 

--- a/docs/pr/PR-114-jp-pii-doc-status-sync.md
+++ b/docs/pr/PR-114-jp-pii-doc-status-sync.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 114
 status: Draft
 created_at: TBD
 branch: feat/jp-pii-doc-status-sync
@@ -12,7 +12,7 @@ title: Sync JP PII implementation status docs
 ## SOT
 - Title: Sync JP PII implementation status docs
 - Status: Draft
-- PR: TBD
+- PR: 114
 
 ## What
 - [x] Mark the JP address validator as implemented and wired after #112.

--- a/docs/pr/PR-TBD-jp-pii-doc-status-sync.md
+++ b/docs/pr/PR-TBD-jp-pii-doc-status-sync.md
@@ -1,0 +1,36 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/jp-pii-doc-status-sync
+commit: 7739ab94661048f7061b0901519750d846a9161d
+title: Sync JP PII implementation status docs
+---
+
+## SOT
+- Title: Sync JP PII implementation status docs
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Mark the JP address validator as implemented and wired after #112.
+- [x] Mark Phase 1 score tuning as complete for the #113 negative-context dampening scope.
+- [x] Keep `Name validator` and `jp_mynumber_checksum` unchecked because they are still follow-up work.
+
+## Verification
+- [x] `git diff --check` — passed.
+- [x] `rg -n "Address validatorは未実装|Address validatorを実装する。現状|validatorなしの住所ヒューリスティック|\[ \] score調整" docs/design/enterprise_jp_pii/04_jp_pii_detection_strategy.md docs/design/enterprise_jp_pii/13_implementation_roadmap.md docs/design/enterprise_jp_pii/DETAIL_DESIGN.md docs/design/enterprise_jp_pii/implementation/task_breakdown.md` — no matches.
+- [x] `cargo run -p veil-cli -- sot --help` — passed.
+
+## Evidence
+- [x] Docs now reference #112 address validator wiring and #113 score context tuning in the implementation status files.
+
+## Non-goals
+- [x] Do not change runtime behavior.
+- [x] Do not mark the Name validator or J-LIS MyNumber checksum as complete.
+- [x] Do not rebalance JP PII base scores or grade thresholds.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- Mark the JP address validator status as complete after #112.
- Mark the Phase 1 score tuning item as complete for the #113 negative-context dampening scope.
- Add #112/#113 implementation status notes to the JP PII task breakdown.

## Why
The implementation docs still described the address rule as validator-less and left score tuning unchecked after both follow-up PRs had already merged. This keeps the design roadmap and implementation task breakdown aligned with the current codebase.

## SOT
- docs/pr/PR-114-jp-pii-doc-status-sync.md

## Validation
- `git diff --check`
- `rg -n "Address validatorは未実装|Address validatorを実装する。現状|validatorなしの住所ヒューリスティック|\[ \] score調整" docs/design/enterprise_jp_pii/04_jp_pii_detection_strategy.md docs/design/enterprise_jp_pii/13_implementation_roadmap.md docs/design/enterprise_jp_pii/DETAIL_DESIGN.md docs/design/enterprise_jp_pii/implementation/task_breakdown.md`
- `cargo run -p veil-cli -- sot --help`