### PR TITLE
Wire JP name validator into name rule

### DIFF
--- a/crates/veil-core/src/validators/jp.rs
+++ b/crates/veil-core/src/validators/jp.rs
@@ -87,6 +87,31 @@ pub fn phone_mobile(candidate: &str) -> bool {
         && (digits.starts_with("070") || digits.starts_with("080") || digits.starts_with("090"))
 }
 
+pub fn person_name_keyword(candidate: &str) -> bool {
+    let normalized = normalize_jp_text(candidate, NormalizationPolicy::default()).normalized;
+    let Some(value) = person_name_value(&normalized) else {
+        return false;
+    };
+    let value = value.trim();
+    let char_count = value.chars().filter(|ch| !ch.is_whitespace()).count();
+
+    if !(2..=40).contains(&char_count) || contains_name_placeholder(value) {
+        return false;
+    }
+
+    if value.chars().any(is_jp_name_char) {
+        return value
+            .chars()
+            .all(|ch| ch.is_whitespace() || is_jp_name_char(ch));
+    }
+
+    let parts: Vec<_> = value.split_whitespace().collect();
+    (2..=4).contains(&parts.len())
+        && parts
+            .iter()
+            .all(|part| part.len() >= 2 && part.chars().all(|ch| ch.is_ascii_alphabetic()))
+}
+
 fn find_prefecture(candidate: &str) -> Option<(usize, usize)> {
     PREFECTURES
         .iter()
@@ -159,6 +184,56 @@ fn is_municipality_marker(ch: char) -> bool {
 
 fn is_mynumber_separator(ch: char) -> bool {
     is_card_separator(ch) || matches!(ch, '－' | '―' | '‐' | '‑' | '–' | '—' | 'ー')
+}
+
+fn person_name_value(content: &str) -> Option<&str> {
+    for label in ["お名前", "氏名", "名前", "Name", "name"] {
+        if let Some(start) = content.find(label) {
+            let after_label = &content[start + label.len()..];
+            return trim_name_label_separator(after_label);
+        }
+    }
+
+    None
+}
+
+fn trim_name_label_separator(content: &str) -> Option<&str> {
+    let content = content.trim_start();
+    if content.starts_with('を') {
+        return None;
+    }
+
+    let content = content
+        .trim_start_matches(|ch| {
+            matches!(
+                ch,
+                ':' | '：' | '=' | 'は' | '-' | ' ' | '\t' | '\u{3000}' | '"' | '\''
+            )
+        })
+        .trim_start();
+    let content = content.trim_matches(|ch| matches!(ch, '"' | '\'' | ' ' | '\t' | '\u{3000}'));
+
+    if content.is_empty() {
+        None
+    } else {
+        Some(content)
+    }
+}
+
+fn contains_name_placeholder(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    [
+        "test", "sample", "dummy", "mock", "version", "class", "function",
+    ]
+    .iter()
+    .any(|word| lower.contains(word))
+        || ["入力", "必須", "サンプル", "テスト", "ダミー", "モック"]
+            .iter()
+            .any(|word| value.contains(word))
+}
+
+fn is_jp_name_char(ch: char) -> bool {
+    matches!(ch, '\u{3041}'..='\u{3096}' | '\u{30A1}'..='\u{30FA}' | '\u{4E00}'..='\u{9FFF}')
 }
 
 fn mynumber_digit_runs(candidate: &str) -> Vec<Vec<u8>> {
@@ -279,5 +354,24 @@ mod tests {
         assert!(phone_mobile("07012345678"));
         assert!(!phone_mobile("050-1234-5678"));
         assert!(!phone_mobile("090-123-4567"));
+    }
+
+    #[test]
+    fn person_name_keyword_accepts_labeled_person_names() {
+        assert!(person_name_keyword("氏名: 山田 太郎"));
+        assert!(person_name_keyword("お名前：佐藤花子"));
+        assert!(person_name_keyword("Name: Taro Yamada"));
+        assert!(person_name_keyword("name = 'Hanako Sato'"));
+    }
+
+    #[test]
+    fn person_name_keyword_rejects_placeholders_and_instructions() {
+        assert!(!person_name_keyword("氏名: "));
+        assert!(!person_name_keyword("お名前を入力してください"));
+        assert!(!person_name_keyword("name = \"test\""));
+        assert!(!person_name_keyword("class Name"));
+        assert!(!person_name_keyword("function name"));
+        assert!(!person_name_keyword("Name: version"));
+        assert!(!person_name_keyword("名前: サンプル"));
     }
 }

--- a/crates/veil-core/src/validators/mod.rs
+++ b/crates/veil-core/src/validators/mod.rs
@@ -6,6 +6,7 @@ pub fn resolve_validator(id: &str) -> Option<ValidatorFn> {
     match id {
         "jp_address_prefecture_city_block" => Some(jp::address_prefecture_city_block),
         "jp_mynumber_len12" => Some(jp::mynumber_len12),
+        "jp_person_name_keyword" => Some(jp::person_name_keyword),
         "jp_phone_mobile" => Some(jp::phone_mobile),
         "luhn" => Some(luhn),
         _ => None,
@@ -230,6 +231,7 @@ mod tests {
     fn resolver_is_allowlisted() {
         assert!(resolve_validator("jp_address_prefecture_city_block").is_some());
         assert!(resolve_validator("jp_mynumber_len12").is_some());
+        assert!(resolve_validator("jp_person_name_keyword").is_some());
         assert!(resolve_validator("jp_phone_mobile").is_some());
         assert!(resolve_validator("luhn").is_some());
         assert!(resolve_validator("unknown").is_none());

--- a/crates/veil-core/tests/jp_pii_fixture_tests.rs
+++ b/crates/veil-core/tests/jp_pii_fixture_tests.rs
@@ -25,6 +25,22 @@ fn jp_address_rule_uses_prefecture_city_block_validator() {
 }
 
 #[test]
+fn jp_name_rule_uses_person_name_validator() {
+    let config = Config::default();
+    let rules = try_get_all_rules(&config, vec![]).unwrap();
+    let rule = rules
+        .iter()
+        .find(|rule| rule.id == "pii.person.name.keyword")
+        .expect("default JP name rule should be loaded");
+
+    assert_eq!(rule.validator_id.as_deref(), Some("jp_person_name_keyword"));
+    assert!(
+        rule.validator.is_some(),
+        "JP name validator should resolve for the built-in rule"
+    );
+}
+
+#[test]
 fn jp_pii_positive_fixtures_match_expected_rules() {
     let fixture_dir = workspace_root()
         .join("tests")

--- a/crates/veil/rules/default/pii.toml
+++ b/crates/veil/rules/default/pii.toml
@@ -227,6 +227,7 @@ tags = ["name", "profile", "heuristic"]
 base_score = 38
 context_lines_before = 1
 context_lines_after = 1
+validator = "jp_person_name_keyword"
 
 [[rules]]
 id = "pii.person.age.keyword"

--- a/crates/veil/rules/default/pii_jp.toml
+++ b/crates/veil/rules/default/pii_jp.toml
@@ -271,6 +271,7 @@ tags = ["name", "profile", "heuristic"]
 base_score = 38
 context_lines_before = 1
 context_lines_after = 1
+validator = "jp_person_name_keyword"
 
 [[rules]]
 id = "pii.person.age.keyword"

--- a/crates/veil/rules_ja/default/pii_jp.toml
+++ b/crates/veil/rules_ja/default/pii_jp.toml
@@ -227,6 +227,7 @@ tags = ["name", "profile", "heuristic"]
 base_score = 38
 context_lines_before = 1
 context_lines_after = 1
+validator = "jp_person_name_keyword"
 
 [[rules]]
 id = "pii.person.age.keyword"

--- a/docs/design/enterprise_jp_pii/04_jp_pii_detection_strategy.md
+++ b/docs/design/enterprise_jp_pii/04_jp_pii_detection_strategy.md
@@ -200,5 +200,5 @@ Fail条件は `score` を正本にする。`--fail-on-severity High` は `score 
 - [x] `veil scan --preset`, `veil init --preset`, `veil config dump --preset` CLI UXを追加。
 - [x] Address validatorを実装し、`pii.jp.address.prefecture_heuristic` に `jp_address_prefecture_city_block` validatorを配線する。
 - [x] negative context score dampeningに `sandbox` と日本語テストデータ文脈を追加する。
-- [ ] Name validatorを実装する。現状の `pii.person.name.keyword` はラベル付きヒューリスティックであり、実装済みvalidatorとは扱わない。
+- [x] Name validatorを実装し、`pii.person.name.keyword` に `jp_person_name_keyword` validatorを配線する。
 - [x] J-LIS MyNumberチェックデジットを feature flag `jp_mynumber_checksum` として実装する。

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -27,7 +27,7 @@
 
 - [x] `jp_normalize` 実装
 - [x] span mapping導入
-- [x] MyNumber validator / Luhn validator / mobile validator / address validator
+- [x] MyNumber validator / Luhn validator / mobile validator / address validator / name validator
 - [x] J-LIS MyNumber checksum feature flag
 - [x] `standard-jp`, `fintech-jp`, `gov-jp`, `si-vendor-jp`, `logs-jp` presets追加
 - [x] Positive/Negative fixtures追加

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -1097,7 +1097,7 @@ Fail条件は `score` を正本にする。`--fail-on-severity High` は `score 
 - [x] `veil scan --preset`, `veil init --preset`, `veil config dump --preset` CLI UXを追加。
 - [x] Address validatorを実装し、`pii.jp.address.prefecture_heuristic` に `jp_address_prefecture_city_block` validatorを配線する。
 - [x] negative context score dampeningに `sandbox` と日本語テストデータ文脈を追加する。
-- [ ] Name validatorを実装する。現状の `pii.person.name.keyword` はラベル付きヒューリスティックであり、実装済みvalidatorとは扱わない。
+- [x] Name validatorを実装し、`pii.person.name.keyword` に `jp_person_name_keyword` validatorを配線する。
 - [x] J-LIS MyNumberチェックデジットを feature flag `jp_mynumber_checksum` として実装する。
 
 ---
@@ -2511,7 +2511,7 @@ PR-0では以下を必須testにする。
 
 - [x] `jp_normalize` 実装
 - [x] span mapping導入
-- [x] MyNumber validator / Luhn validator / mobile validator / address validator
+- [x] MyNumber validator / Luhn validator / mobile validator / address validator / name validator
 - [x] J-LIS MyNumber checksum feature flag
 - [x] `standard-jp`, `fintech-jp`, `gov-jp`, `si-vendor-jp`, `logs-jp` presets追加
 - [x] Positive/Negative fixtures追加

--- a/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
+++ b/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
@@ -35,7 +35,7 @@
 - [x] MyNumber validator / Luhn validator / mobile validator
 - [x] Positive/Negative fixtures追加
 - [x] Address validatorは #112 で実装・配線済み。`pii.jp.address.prefecture_heuristic` は `jp_address_prefecture_city_block` validatorを使う。
-- [ ] Name validatorは未実装。現状はvalidatorなしのラベル付き氏名ヒューリスティックのみ。
+- [x] Name validatorは実装・配線済み。`pii.person.name.keyword` は `jp_person_name_keyword` validatorを使う。
 - [x] J-LIS MyNumberチェックデジットは default off の feature flag `jp_mynumber_checksum` で実装済み。
 
 ## #103 JP preset override resolver（merge済み）

--- a/docs/pr/PR-116-jp-name-validator.md
+++ b/docs/pr/PR-116-jp-name-validator.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 116
 status: Draft
 created_at: TBD
 branch: feat/jp-name-validator
@@ -12,7 +12,7 @@ title: Wire JP name validator into name rule
 ## SOT
 - Title: Wire JP name validator into name rule
 - Status: Draft
-- PR: TBD
+- PR: 116
 
 ## What
 - [x] Add `jp_person_name_keyword` validator for labeled JP/EN person-name findings.

--- a/docs/pr/PR-TBD-jp-name-validator.md
+++ b/docs/pr/PR-TBD-jp-name-validator.md
@@ -1,0 +1,42 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/jp-name-validator
+commit: 09cf41da04dea80de8877ce043dd50b2f52dc2c1
+title: Wire JP name validator into name rule
+---
+
+## SOT
+- Title: Wire JP name validator into name rule
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add `jp_person_name_keyword` validator for labeled JP/EN person-name findings.
+- [x] Wire `pii.person.name.keyword` to the validator in default JP rule packs.
+- [x] Add positive and negative JP PII fixtures for labeled names, placeholders, and instruction text.
+- [x] Add a built-in rule resolution test for the name validator.
+- [x] Mark the Name validator item complete in the JP PII design/task docs.
+
+## Verification
+- [x] `cargo fmt --all --check` — passed.
+- [x] `git diff --check` — passed.
+- [x] `cargo test -p veil-core person_name -- --nocapture` — passed.
+- [x] `cargo test -p veil-core jp_pii -- --nocapture` — passed.
+- [x] `cargo test -p veil-core --all-features jp_pii -- --nocapture` — passed.
+- [x] `cargo clippy -p veil-core --all-targets --all-features -- -D warnings` — passed.
+
+## Evidence
+- [x] `tests/fixtures/jp_pii/positive/person_name_keyword.txt` covers a valid labeled name.
+- [x] `tests/fixtures/jp_pii/negative/name_labels_without_values.txt` covers empty labels, input instructions, and placeholder/dev values.
+
+## Non-goals
+- [x] Do not add unlabeled name detection.
+- [x] Do not infer names without `pii.person.name.keyword` matching first.
+- [x] Do not change scores or severity bands.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.

--- a/tests/fixtures/jp_pii/negative/name_labels_without_values.txt
+++ b/tests/fixtures/jp_pii/negative/name_labels_without_values.txt
@@ -1,0 +1,7 @@
+氏名:
+お名前を入力してください
+name = "test"
+class Name
+function name
+Name: version
+名前: サンプル

--- a/tests/fixtures/jp_pii/positive/person_name_keyword.txt
+++ b/tests/fixtures/jp_pii/positive/person_name_keyword.txt
@@ -1,0 +1,3 @@
+# EXPECT: pii.person.name.keyword
+
+氏名: 山田 太郎


### PR DESCRIPTION
---
release: TBD
epic: A
pr: 116
status: Draft
created_at: TBD
branch: feat/jp-name-validator
commit: 09cf41da04dea80de8877ce043dd50b2f52dc2c1
title: Wire JP name validator into name rule
---

## SOT
- Title: Wire JP name validator into name rule
- Status: Draft
- PR: 116

## What
- [x] Add `jp_person_name_keyword` validator for labeled JP/EN person-name findings.
- [x] Wire `pii.person.name.keyword` to the validator in default JP rule packs.
- [x] Add positive and negative JP PII fixtures for labeled names, placeholders, and instruction text.
- [x] Add a built-in rule resolution test for the name validator.
- [x] Mark the Name validator item complete in the JP PII design/task docs.

## Verification
- [x] `cargo fmt --all --check` — passed.
- [x] `git diff --check` — passed.
- [x] `cargo test -p veil-core person_name -- --nocapture` — passed.
- [x] `cargo test -p veil-core jp_pii -- --nocapture` — passed.
- [x] `cargo test -p veil-core --all-features jp_pii -- --nocapture` — passed.
- [x] `cargo clippy -p veil-core --all-targets --all-features -- -D warnings` — passed.

## Evidence
- [x] `tests/fixtures/jp_pii/positive/person_name_keyword.txt` covers a valid labeled name.
- [x] `tests/fixtures/jp_pii/negative/name_labels_without_values.txt` covers empty labels, input instructions, and placeholder/dev values.

## Non-goals
- [x] Do not add unlabeled name detection.
- [x] Do not infer names without `pii.person.name.keyword` matching first.
- [x] Do not change scores or severity bands.

## Rollback
- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.
