### PR TITLE
Add UI API contract types

### DIFF
--- a/crates/veil-pro/frontend/src/lib/Dashboard.svelte
+++ b/crates/veil-pro/frontend/src/lib/Dashboard.svelte
@@ -2,8 +2,18 @@
   import { Shield, LayoutDashboard, ScanSearch, FileCheck2, Settings, UserCircle, LogOut } from 'lucide-svelte';
   import ScanView from './ScanView.svelte';
 
+  type DashboardProps = {
+    authType?: string | null;
+    userName?: string | null;
+    userEmail?: string | null;
+  };
+
+  let { authType = null, userName = null, userEmail = null }: DashboardProps = $props();
+
   // v1.0.0 strict local-first architecture (No SSO, Local Token Auth)
   let currentView = $state('scan');
+  let displayName = $derived(userName || userEmail || 'Local Admin');
+  let sessionLabel = $derived(authType === 'sso' ? 'SSO Session' : 'CLI Session');
 </script>
 
 <div class="dashboard-layout">
@@ -39,8 +49,8 @@
     <div class="user-profile">
       <UserCircle size={32} color="var(--text-secondary)" />
       <div class="user-info">
-        <strong>Local Admin</strong>
-        <span>CLI Session</span>
+        <strong>{displayName}</strong>
+        <span>{sessionLabel}</span>
       </div>
     </div>
   </aside>

--- a/crates/veil-pro/frontend/src/lib/ScanView.svelte
+++ b/crates/veil-pro/frontend/src/lib/ScanView.svelte
@@ -1,40 +1,43 @@
 <script lang="ts">
   import { FolderSearch, AlertTriangle, ShieldCheck, Play, Loader2, RotateCcw } from 'lucide-svelte';
+  import type { ErrorEnvelope, PresetName, SafeFindingApiV1, ScanRequest, ScanResponse, SeverityName } from './api-contract';
   
   // Strict State Machine for UI prediction and tracking (no implicit states)
   type ScanState = 'Idle' | 'Running' | 'SuccessNoFindings' | 'Violation' | 'Incomplete' | 'ErrorAuth' | 'ErrorConfig' | 'ErrorExpired' | 'ErrorOOM' | 'ErrorUnknown';
-  type ScanPresetId = 'standard-jp' | 'fintech-jp' | 'gov-jp' | 'si-vendor-jp' | 'logs-jp';
-  type ScanPreset = '' | ScanPresetId;
+  type ScanPreset = '' | PresetName;
   let currentState = $state<ScanState>('Idle');
   
   let scanPath = $state('');
   let scanPreset = $state<ScanPreset>('');
-  let findings = $state<any[]>([]);
+  let findings = $state<SafeFindingApiV1[]>([]);
   let scanStats = $state<{scanned: number, skipped: number, runId: string} | null>(null);
   let errorMsg = $state<string | null>(null);
 
-  const sevWeights: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+  const sevWeights: Record<SeverityName, number> = { Critical: 4, High: 3, Medium: 2, Low: 1 };
   
   let sortedFindings = $derived(
     [...findings].sort((a, b) => {
-      const weightA = sevWeights[String(a.severity || '').toLowerCase()] || 0;
-      const weightB = sevWeights[String(b.severity || '').toLowerCase()] || 0;
+      const weightA = sevWeights[a.severity];
+      const weightB = sevWeights[b.severity];
       return weightB - weightA;
     })
   );
 
-  function safeInt(v: any, fallback = 0): number {
+  function safeInt(v: unknown, fallback = 0): number {
     const n = Number.parseInt(String(v), 10);
     return Number.isFinite(n) ? n : fallback;
   }
 
   async function readErrorMessage(res: Response, fallback: string): Promise<string> {
-    const err = await res.json().catch(() => ({}));
+    const err = await res.json().catch(() => null) as Partial<ErrorEnvelope> & { error?: unknown; message?: unknown } | null;
     if (typeof err?.error === 'string') {
       return err.error;
     }
-    if (typeof err?.error?.message === 'string') {
-      return err.error.message;
+    if (err?.error && typeof err.error === 'object' && 'message' in err.error) {
+      const message = err.error.message;
+      if (typeof message === 'string') {
+        return message;
+      }
     }
     if (typeof err?.message === 'string') {
       return err.message;
@@ -60,7 +63,7 @@
         headers['Authorization'] = `Bearer ${token}`;
       }
 
-      const requestBody: { paths: string[]; preset?: ScanPresetId } = { paths: [targetPath] };
+      const requestBody: ScanRequest = { paths: [targetPath] };
       if (scanPreset !== '') {
         requestBody.preset = scanPreset;
       }
@@ -92,8 +95,8 @@
         return;
       }
 
-      const data = await res.json();
-      findings = data.findings || [];
+      const data = await res.json() as ScanResponse;
+      findings = data.findings;
       scanStats = {
         scanned: data.scannedFiles,
         skipped: data.skippedFiles,
@@ -108,9 +111,9 @@
         currentState = 'SuccessNoFindings';
       }
       
-    } catch (err: any) {
+    } catch (err: unknown) {
       currentState = 'ErrorUnknown';
-      errorMsg = err.message || 'An unknown network error occurred';
+      errorMsg = err instanceof Error ? err.message : 'An unknown network error occurred';
     }
   }
 
@@ -154,7 +157,7 @@
       a.click();
       a.remove();
       window.URL.revokeObjectURL(url);
-    } catch (e: any) {
+    } catch (_err: unknown) {
       currentState = 'ErrorUnknown';
       errorMsg = 'Network error downloading evidence.';
     }

--- a/crates/veil-pro/frontend/src/lib/api-contract.ts
+++ b/crates/veil-pro/frontend/src/lib/api-contract.ts
@@ -1,0 +1,85 @@
+// UI-facing subset of schemas/openapi.local-api.yaml.
+// Keep these names and casing aligned with crates/veil-pro/src/api/dto.rs.
+export type LocalApiSchemaVersion = 'veil-pro-local-api-v1';
+export type SeverityName = 'Low' | 'Medium' | 'High' | 'Critical';
+export type GradeName = 'Low' | 'Medium' | 'High' | 'Critical';
+export type BaselineStatus = 'none' | 'new' | 'suppressed';
+export type PresetName = 'standard-jp' | 'fintech-jp' | 'gov-jp' | 'si-vendor-jp' | 'logs-jp';
+export type ScanMode = 'full' | 'staged' | 'ci';
+export type RunStatus = 'success' | 'violation' | 'incomplete' | 'error';
+export type ErrorCode =
+  | 'INVALID_REQUEST'
+  | 'UNAUTHORIZED'
+  | 'PATH_DENIED'
+  | 'NOT_FOUND'
+  | 'RUN_EXPIRED'
+  | 'RUN_TOO_LARGE'
+  | 'INTERNAL_ERROR';
+export type NextAction =
+  | 'RESCAN'
+  | 'CHECK_TOKEN'
+  | 'NARROW_SCOPE'
+  | 'OPEN_DOCTOR'
+  | 'COMMIT_BASELINE'
+  | 'REVIEW_FINDINGS';
+
+export type SeverityCounts = {
+  Low: number;
+  Medium: number;
+  High: number;
+  Critical: number;
+};
+
+export type ScanRequest = {
+  paths?: string[] | null;
+  preset?: PresetName | null;
+  mode?: ScanMode | null;
+  baselineFile?: string | null;
+  includeSuppressed?: boolean;
+  failOnScore?: number | null;
+  failOnSeverity?: SeverityName | null;
+  failOnFindings?: number | null;
+};
+
+export type SafeFindingApiV1 = {
+  findingId: string;
+  baselineFingerprint: string;
+  path: string;
+  lineNumber: number;
+  ruleId: string;
+  severity: SeverityName;
+  score: number;
+  grade: GradeName;
+  maskedSnippet: string;
+  category: string;
+  tags: string[];
+  baselineStatus: BaselineStatus;
+};
+
+export type ScanResponse = {
+  schemaVersion: LocalApiSchemaVersion;
+  runId: string;
+  status: RunStatus;
+  scannedFiles: number;
+  skippedFiles: number;
+  totalFindings: number;
+  suppressedFindings: number;
+  effectiveFindings: number;
+  coverageComplete: boolean;
+  severityCounts: SeverityCounts;
+  allSeverityCounts: SeverityCounts;
+  suppressedSeverityCounts: SeverityCounts;
+  limitReached: boolean;
+  limitReasons: string[];
+  builtinSkips: string[];
+  findings: SafeFindingApiV1[];
+  expiresAtUtc: string;
+};
+
+export type ErrorEnvelope = {
+  error: {
+    code: ErrorCode;
+    message: string;
+    nextAction?: NextAction | null;
+  };
+};

--- a/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
+++ b/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
@@ -57,7 +57,7 @@
 
 - [x] Local API scanで `PresetName` を builtin preset configへ解決する。
 - [x] `logs-jp` scanではCLIと同じく `rules/log` RulePackを必須にする。
-- [ ] OpenAPI generated schemaをUI clientへ反映。
+- [x] OpenAPI generated schemaをUI clientへ反映。
 - [x] UI scan requestでpresetを渡せる最小導線を確認する。
 - [ ] `includeSuppressed` UI toggle
 - [ ] limit reached / coverageComplete UI表示

--- a/docs/pr/PR-117-ui-api-contract-types.md
+++ b/docs/pr/PR-117-ui-api-contract-types.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 117
 status: Draft
 created_at: TBD
 branch: feat/ui-api-contract-types
@@ -12,7 +12,7 @@ title: Add UI API contract types
 ## SOT
 - Title: Add UI API contract types
 - Status: Draft
-- PR: TBD
+- PR: 117
 
 ## What
 - [x] Add `api-contract.ts` with the UI-facing subset of the generated Local API/OpenAPI contract.

--- a/docs/pr/PR-TBD-ui-api-contract-types.md
+++ b/docs/pr/PR-TBD-ui-api-contract-types.md
@@ -1,0 +1,39 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/ui-api-contract-types
+commit: c6edb2ef6bfb1ccd05c3e6cd7edff3d2aac8eb5f
+title: Add UI API contract types
+---
+
+## SOT
+- Title: Add UI API contract types
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add `api-contract.ts` with the UI-facing subset of the generated Local API/OpenAPI contract.
+- [x] Type `ScanView` request/response/findings against the Local API contract instead of `any` and inline request shapes.
+- [x] Declare `Dashboard` props so `App.svelte` -> `Dashboard.svelte` type checking is explicit.
+- [x] Mark the #106 UI client contract reflection task complete in the JP PII implementation breakdown.
+
+## Verification
+- [x] `npm run check` in `crates/veil-pro/frontend` — passed.
+- [x] `npm run build` in `crates/veil-pro/frontend` — passed.
+- [x] `git diff --check` — passed.
+
+## Evidence
+- [x] `crates/veil-pro/frontend/src/lib/api-contract.ts` mirrors the Local API types consumed by the scan UI.
+- [x] `crates/veil-pro/frontend/src/lib/ScanView.svelte` consumes `ScanRequest`, `ScanResponse`, and `SafeFindingApiV1`.
+- [x] `docs/design/enterprise_jp_pii/implementation/task_breakdown.md` records the completed #106 UI contract reflection task.
+
+## Non-goals
+- [x] Do not add the `includeSuppressed` UI toggle.
+- [x] Do not change limit reached / `coverageComplete` presentation.
+- [x] Do not add new frontend package dependencies or generated TypeScript tooling.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
---
release: TBD
epic: A
pr: 117
status: Draft
created_at: TBD
branch: feat/ui-api-contract-types
commit: c6edb2ef6bfb1ccd05c3e6cd7edff3d2aac8eb5f
title: Add UI API contract types
---

## SOT
- Title: Add UI API contract types
- Status: Draft
- PR: 117

## What
- [x] Add `api-contract.ts` with the UI-facing subset of the generated Local API/OpenAPI contract.
- [x] Type `ScanView` request/response/findings against the Local API contract instead of `any` and inline request shapes.
- [x] Declare `Dashboard` props so `App.svelte` -> `Dashboard.svelte` type checking is explicit.
- [x] Mark the #106 UI client contract reflection task complete in the JP PII implementation breakdown.

## Verification
- [x] `npm run check` in `crates/veil-pro/frontend` — passed.
- [x] `npm run build` in `crates/veil-pro/frontend` — passed.
- [x] `git diff --check` — passed.

## Evidence
- [x] `crates/veil-pro/frontend/src/lib/api-contract.ts` mirrors the Local API types consumed by the scan UI.
- [x] `crates/veil-pro/frontend/src/lib/ScanView.svelte` consumes `ScanRequest`, `ScanResponse`, and `SafeFindingApiV1`.
- [x] `docs/design/enterprise_jp_pii/implementation/task_breakdown.md` records the completed #106 UI contract reflection task.

## Non-goals
- [x] Do not add the `includeSuppressed` UI toggle.
- [x] Do not change limit reached / `coverageComplete` presentation.
- [x] Do not add new frontend package dependencies or generated TypeScript tooling.

## Rollback
- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.
