### PR TITLE
Add include suppressed scan toggle

### DIFF
--- a/crates/veil-pro/frontend/src/lib/ScanView.svelte
+++ b/crates/veil-pro/frontend/src/lib/ScanView.svelte
@@ -9,17 +9,27 @@
   
   let scanPath = $state('');
   let scanPreset = $state<ScanPreset>('');
+  let includeSuppressed = $state(false);
   let findings = $state<SafeFindingApiV1[]>([]);
-  let scanStats = $state<{scanned: number, skipped: number, runId: string} | null>(null);
+  let scanStats = $state<{
+    scanned: number;
+    skipped: number;
+    runId: string;
+    effectiveFindings: number;
+    suppressedFindings: number;
+    totalFindings: number;
+  } | null>(null);
   let errorMsg = $state<string | null>(null);
 
   const sevWeights: Record<SeverityName, number> = { Critical: 4, High: 3, Medium: 2, Low: 1 };
   
   let sortedFindings = $derived(
     [...findings].sort((a, b) => {
+      const statusA = a.baselineStatus === 'suppressed' ? 0 : 1;
+      const statusB = b.baselineStatus === 'suppressed' ? 0 : 1;
       const weightA = sevWeights[a.severity];
       const weightB = sevWeights[b.severity];
-      return weightB - weightA;
+      return statusB - statusA || weightB - weightA;
     })
   );
 
@@ -67,6 +77,9 @@
       if (scanPreset !== '') {
         requestBody.preset = scanPreset;
       }
+      if (includeSuppressed) {
+        requestBody.includeSuppressed = true;
+      }
 
       const res = await fetch('/api/scan', {
         method: 'POST',
@@ -100,12 +113,15 @@
       scanStats = {
         scanned: data.scannedFiles,
         skipped: data.skippedFiles,
-        runId: data.runId
+        runId: data.runId,
+        effectiveFindings: data.effectiveFindings,
+        suppressedFindings: data.suppressedFindings,
+        totalFindings: data.totalFindings
       };
       
       if (data.limitReached) {
         currentState = 'Incomplete';
-      } else if (findings.length > 0) {
+      } else if (data.effectiveFindings > 0) {
         currentState = 'Violation';
       } else {
         currentState = 'SuccessNoFindings';
@@ -185,6 +201,15 @@
         <option value="si-vendor-jp">si-vendor-jp</option>
         <option value="logs-jp">logs-jp</option>
       </select>
+      <label class="toggle-row">
+        <input
+          type="checkbox"
+          bind:checked={includeSuppressed}
+          disabled={currentState === 'Running'}
+        />
+        <span class="toggle-switch" aria-hidden="true"></span>
+        <span class="toggle-label">Include Suppressed</span>
+      </label>
       <button type="submit" class="btn btn-primary" disabled={currentState === 'Running'}>
         {#if currentState === 'Running'}
           <Loader2 size={18} class="spin" /> Scanning...
@@ -218,9 +243,15 @@
           <span class="stat-label">Files Scanned</span>
         </div>
         <div class="stat-card glass-panel">
-          <span class="stat-value">{safeInt(findings.length)}</span>
+          <span class="stat-value">{safeInt(scanStats.effectiveFindings)}</span>
           <span class="stat-label">Active Findings</span>
         </div>
+        {#if includeSuppressed || scanStats.suppressedFindings > 0}
+          <div class="stat-card glass-panel">
+            <span class="stat-value">{safeInt(scanStats.suppressedFindings)}</span>
+            <span class="stat-label">Suppressed</span>
+          </div>
+        {/if}
         {#if currentState === 'SuccessNoFindings'}
           <div class="stat-card glass-panel success-card">
             <ShieldCheck size={32} color="var(--success)" />
@@ -242,6 +273,7 @@
             <table>
               <thead>
                 <tr>
+                  <th>Status</th>
                   <th>Severity</th>
                   <th>Rule</th>
                   <th>Target File</th>
@@ -251,6 +283,11 @@
               <tbody>
                 {#each sortedFindings as finding}
                   <tr>
+                    <td>
+                      <span class="badge status-{finding.baselineStatus === 'suppressed' ? 'suppressed' : 'active'}">
+                        {finding.baselineStatus === 'suppressed' ? 'Suppressed' : 'Active'}
+                      </span>
+                    </td>
                     <td>
                       <!-- Strict CSP: Use CSS classes instead of inline style -->
                       <span class="badge sev-{String(finding.severity || '').toLowerCase()}">
@@ -312,7 +349,7 @@
 
   .scan-form {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(160px, 220px) auto;
+    grid-template-columns: minmax(0, 1fr) minmax(160px, 220px) minmax(180px, auto) auto;
     gap: 12px;
   }
 
@@ -347,6 +384,66 @@
   
   input[type="text"]:disabled,
   select:disabled {
+    opacity: 0.6;
+  }
+
+  .toggle-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 44px;
+    color: var(--text-primary);
+    font-size: 14px;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .toggle-row input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .toggle-switch {
+    position: relative;
+    width: 38px;
+    height: 22px;
+    border-radius: 999px;
+    background: var(--glass-border);
+    transition: background 0.2s, box-shadow 0.2s;
+    flex: 0 0 auto;
+  }
+
+  .toggle-switch::after {
+    content: "";
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--bg-primary);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+    transition: transform 0.2s;
+  }
+
+  .toggle-row input:checked + .toggle-switch {
+    background: var(--accent);
+  }
+
+  .toggle-row input:checked + .toggle-switch::after {
+    transform: translateX(16px);
+  }
+
+  .toggle-row input:focus-visible + .toggle-switch {
+    box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.3);
+  }
+
+  .toggle-row input:disabled + .toggle-switch,
+  .toggle-row input:disabled ~ .toggle-label {
     opacity: 0.6;
   }
 
@@ -479,6 +576,17 @@
     font-weight: 600;
     font-size: 12px;
     letter-spacing: 0.02em;
+  }
+
+  .status-active {
+    color: var(--success);
+    background: rgba(52, 199, 89, 0.1);
+  }
+
+  .status-suppressed {
+    color: var(--text-secondary);
+    background: var(--bg-primary);
+    border: 1px solid var(--glass-border);
   }
 
   .rule-col { font-weight: 500; }

--- a/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
+++ b/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
@@ -59,7 +59,7 @@
 - [x] `logs-jp` scanではCLIと同じく `rules/log` RulePackを必須にする。
 - [x] OpenAPI generated schemaをUI clientへ反映。
 - [x] UI scan requestでpresetを渡せる最小導線を確認する。
-- [ ] `includeSuppressed` UI toggle
+- [x] `includeSuppressed` UI toggle
 - [ ] limit reached / coverageComplete UI表示
 
 ## #112 JP address validator wiring（merge済み）

--- a/docs/pr/PR-118-ui-include-suppressed-toggle.md
+++ b/docs/pr/PR-118-ui-include-suppressed-toggle.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 118
 status: Draft
 created_at: TBD
 branch: feat/ui-include-suppressed-toggle
@@ -12,7 +12,7 @@ title: Add include suppressed scan toggle
 ## SOT
 - Title: Add include suppressed scan toggle
 - Status: Draft
-- PR: TBD
+- PR: 118
 
 ## What
 - [x] Add an `Include Suppressed` toggle to the scan form.

--- a/docs/pr/PR-TBD-ui-include-suppressed-toggle.md
+++ b/docs/pr/PR-TBD-ui-include-suppressed-toggle.md
@@ -1,0 +1,41 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/ui-include-suppressed-toggle
+commit: 6772bc59782baa88b0896eeaa90f9cfbc887712f
+title: Add include suppressed scan toggle
+---
+
+## SOT
+- Title: Add include suppressed scan toggle
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add an `Include Suppressed` toggle to the scan form.
+- [x] Send `includeSuppressed: true` only when the toggle is enabled.
+- [x] Keep Active Findings based on `effectiveFindings`, even when suppressed findings are included.
+- [x] Add a Status column so suppressed findings are visually distinguishable from active findings.
+- [x] Mark the #106 `includeSuppressed` UI toggle task complete.
+
+## Verification
+- [x] `npm ci` in `crates/veil-pro/frontend` — passed.
+- [x] `npm run check` in `crates/veil-pro/frontend` — passed.
+- [x] `npm run build` in `crates/veil-pro/frontend` — passed.
+- [x] `git diff --check` — passed.
+
+## Evidence
+- [x] `crates/veil-pro/frontend/src/lib/ScanView.svelte` sends the typed `includeSuppressed` request flag.
+- [x] `crates/veil-pro/frontend/src/lib/ScanView.svelte` renders Active/Suppressed status badges in scan results.
+- [x] `docs/design/enterprise_jp_pii/implementation/task_breakdown.md` records the completed #106 toggle task.
+
+## Non-goals
+- [x] Do not change Local API response semantics.
+- [x] Do not add limit reached / `coverageComplete` UI presentation.
+- [x] Do not update frontend dependencies or address existing npm audit findings.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
---
release: TBD
epic: A
pr: 118
status: Draft
created_at: TBD
branch: feat/ui-include-suppressed-toggle
commit: 6772bc59782baa88b0896eeaa90f9cfbc887712f
title: Add include suppressed scan toggle
---

## SOT
- Title: Add include suppressed scan toggle
- Status: Draft
- PR: 118

## What
- [x] Add an `Include Suppressed` toggle to the scan form.
- [x] Send `includeSuppressed: true` only when the toggle is enabled.
- [x] Keep Active Findings based on `effectiveFindings`, even when suppressed findings are included.
- [x] Add a Status column so suppressed findings are visually distinguishable from active findings.
- [x] Mark the #106 `includeSuppressed` UI toggle task complete.

## Verification
- [x] `npm ci` in `crates/veil-pro/frontend` — passed.
- [x] `npm run check` in `crates/veil-pro/frontend` — passed.
- [x] `npm run build` in `crates/veil-pro/frontend` — passed.
- [x] `git diff --check` — passed.

## Evidence
- [x] `crates/veil-pro/frontend/src/lib/ScanView.svelte` sends the typed `includeSuppressed` request flag.
- [x] `crates/veil-pro/frontend/src/lib/ScanView.svelte` renders Active/Suppressed status badges in scan results.
- [x] `docs/design/enterprise_jp_pii/implementation/task_breakdown.md` records the completed #106 toggle task.

## Non-goals
- [x] Do not change Local API response semantics.
- [x] Do not add limit reached / `coverageComplete` UI presentation.
- [x] Do not update frontend dependencies or address existing npm audit findings.

## Rollback
- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.
