### PR TITLE
Document JP preset UX in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ veil config check
 veil scan .
 ```
 
+## 🇯🇵 JP Preset Quickstart
+
+日本向けのスキャンでは、用途別presetをbase layerとして適用できます。`veil.toml`、`VEIL_ORG_CONFIG`、repo設定はpreset由来の値を上書きできます。
+
+```bash
+# 金融/決済向けのJP PII設定で初期化
+veil init --preset fintech-jp
+
+# presetを一時的に適用してスキャン
+veil scan . --preset fintech-jp
+
+# preset layerだけを確認
+veil config dump --preset fintech-jp --layer preset
+```
+
+利用可能なpresetは `standard-jp`, `fintech-jp`, `gov-jp`, `si-vendor-jp`, `logs-jp` です。ログ監査向けの `logs-jp` は `rules/log` RulePackを必要とするため、先に `veil init --preset logs-jp` を実行してください。
+
+Veil Pro ダッシュボードのscan画面でもpresetを選択できます。baselineで抑制済みのfindingを確認する場合は `Include Suppressed` を有効にし、scanがlimit到達または `coverageComplete=false` になった場合はCoverage表示と理由チップを確認してください。
+
 ## 🖥️ Veil Pro ダッシュボード・クイックスタート
 **Veil Pro ダッシュボード** は、日々の誤検知トリアージ、ノイズ管理、および監査証跡の作成を行う「ローカル向けコマンドセンター」です。B2Bグレードのセキュリティ（完全オフライン、ゼロ・テレメトリ）を備えています。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -59,6 +59,25 @@ cargo install --path crates/veil-cli --bin veil
 veil scan .
 ```
 
+### Japan Preset Quickstart
+
+For Japan-focused scans, apply a purpose-built preset as the base config layer. Project config, `VEIL_ORG_CONFIG`, and repo-local settings can still override preset values.
+
+```bash
+# Initialize a fintech/JP PII-oriented config
+veil init --preset fintech-jp
+
+# Apply the preset for one scan
+veil scan . --preset fintech-jp
+
+# Inspect only the preset layer
+veil config dump --preset fintech-jp --layer preset
+```
+
+Available presets are `standard-jp`, `fintech-jp`, `gov-jp`, `si-vendor-jp`, and `logs-jp`. The log-audit `logs-jp` preset requires the `rules/log` RulePack, so run `veil init --preset logs-jp` before scanning with it.
+
+The Veil Pro Dashboard scan view also supports preset selection. Enable `Include Suppressed` to review baseline-suppressed findings, and use the Coverage card plus reason chips when a scan reaches a limit or returns `coverageComplete=false`.
+
 ### Veil Pro Dashboard Quickstart
 The **Veil Pro Dashboard** acts as your local "command center" for daily triage, noise management, and auditing, featuring B2B-grade security measures like local-first isolation and Zero Telemetry.
 

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -46,7 +46,7 @@ PR分割:
 - [x] `veil init --preset` 実装
 - [x] `veil scan --preset` 実装
 - [ ] wizard推論ロジック
-- [ ] docs/README更新
+- [x] docs/README更新
 - [x] `veil config dump --preset` 実装
 - [x] Local API / UI の preset対応（#106: Local API scan preset解決 + 最小UI selector。大きなUI workflow改修はPhase 5）
 

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2530,7 +2530,7 @@ PR分割:
 - [x] `veil init --preset` 実装
 - [x] `veil scan --preset` 実装
 - [ ] wizard推論ロジック
-- [ ] docs/README更新
+- [x] docs/README更新
 - [x] `veil config dump --preset` 実装
 - [x] Local API / UI の preset対応（#106: Local API scan preset解決 + 最小UI selector。大きなUI workflow改修はPhase 5）
 

--- a/docs/pr/PR-120-readme-preset-ux-docs.md
+++ b/docs/pr/PR-120-readme-preset-ux-docs.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 120
 status: Draft
 created_at: TBD
 branch: feat/readme-preset-ux-docs
@@ -12,7 +12,7 @@ title: Document JP preset UX in README
 ## SOT
 - Title: Document JP preset UX in README
 - Status: Draft
-- PR: TBD
+- PR: 120
 
 ## What
 - [x] Add JP preset quickstart guidance to `README.md`.

--- a/docs/pr/PR-TBD-readme-preset-ux-docs.md
+++ b/docs/pr/PR-TBD-readme-preset-ux-docs.md
@@ -1,0 +1,39 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/readme-preset-ux-docs
+commit: 8859eed4b6afa341ad9efc1cf12bca8f45d9a6f5
+title: Document JP preset UX in README
+---
+
+## SOT
+- Title: Document JP preset UX in README
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add JP preset quickstart guidance to `README.md`.
+- [x] Add matching preset quickstart guidance to `README_EN.md`.
+- [x] Document `veil init --preset`, `veil scan --preset`, `veil config dump --preset --layer preset`, and the `logs-jp` RulePack requirement.
+- [x] Mention the dashboard preset selector, `Include Suppressed`, and coverage/limit UI indicators.
+- [x] Mark the Phase 2 docs/README task complete in roadmap docs.
+
+## Verification
+- [x] `git diff --check` — passed.
+- [x] `rg -n "JP Preset Quickstart|Japan Preset Quickstart|docs/README更新|Include Suppressed|coverageComplete" ...` — passed.
+
+## Evidence
+- [x] `README.md` and `README_EN.md` now expose the implemented preset UX.
+- [x] `docs/design/enterprise_jp_pii/13_implementation_roadmap.md` marks `docs/README更新` complete.
+- [x] `docs/design/enterprise_jp_pii/DETAIL_DESIGN.md` mirrors the roadmap completion state.
+
+## Non-goals
+- [x] Do not change CLI, Local API, or UI behavior.
+- [x] Do not add `CoreConfig.preset`.
+- [x] Do not implement wizard inference logic.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
---
release: TBD
epic: A
pr: 120
status: Draft
created_at: TBD
branch: feat/readme-preset-ux-docs
commit: 8859eed4b6afa341ad9efc1cf12bca8f45d9a6f5
title: Document JP preset UX in README
---

## SOT
- Title: Document JP preset UX in README
- Status: Draft
- PR: 120

## What
- [x] Add JP preset quickstart guidance to `README.md`.
- [x] Add matching preset quickstart guidance to `README_EN.md`.
- [x] Document `veil init --preset`, `veil scan --preset`, `veil config dump --preset --layer preset`, and the `logs-jp` RulePack requirement.
- [x] Mention the dashboard preset selector, `Include Suppressed`, and coverage/limit UI indicators.
- [x] Mark the Phase 2 docs/README task complete in roadmap docs.

## Verification
- [x] `git diff --check` — passed.
- [x] `rg -n "JP Preset Quickstart|Japan Preset Quickstart|docs/README更新|Include Suppressed|coverageComplete" ...` — passed.

## Evidence
- [x] `README.md` and `README_EN.md` now expose the implemented preset UX.
- [x] `docs/design/enterprise_jp_pii/13_implementation_roadmap.md` marks `docs/README更新` complete.
- [x] `docs/design/enterprise_jp_pii/DETAIL_DESIGN.md` mirrors the roadmap completion state.

## Non-goals
- [x] Do not change CLI, Local API, or UI behavior.
- [x] Do not add `CoreConfig.preset`.
- [x] Do not implement wizard inference logic.

## Rollback
- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.
