### PR TITLE
Add wizard preset inference

### DIFF
--- a/crates/veil-cli/src/commands/init.rs
+++ b/crates/veil-cli/src/commands/init.rs
@@ -406,6 +406,68 @@ fn validate_log_pack_for_init(rules_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(any(feature = "wizard", test))]
+pub fn infer_wizard_preset(root: &Path) -> Option<&'static str> {
+    if has_log_artifact(root) {
+        return Some("logs-jp");
+    }
+
+    if has_fintech_directory(root) {
+        return Some("fintech-jp");
+    }
+
+    if readme_contains_japanese(root) {
+        return Some("standard-jp");
+    }
+
+    None
+}
+
+#[cfg(any(feature = "wizard", test))]
+fn has_log_artifact(root: &Path) -> bool {
+    if root.join("logs").is_dir() {
+        return true;
+    }
+
+    fs::read_dir(root)
+        .map(|entries| {
+            entries.flatten().any(|entry| {
+                let path = entry.path();
+                path.is_file()
+                    && path
+                        .extension()
+                        .and_then(|ext| ext.to_str())
+                        .map(|ext| matches!(ext, "log" | "jsonl" | "ndjson"))
+                        .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(any(feature = "wizard", test))]
+fn has_fintech_directory(root: &Path) -> bool {
+    ["payments", "billing", "kyc", "account"]
+        .iter()
+        .any(|name| root.join(name).is_dir())
+}
+
+#[cfg(any(feature = "wizard", test))]
+fn readme_contains_japanese(root: &Path) -> bool {
+    fs::read_to_string(root.join("README.md"))
+        .map(|content| contains_japanese_text(&content))
+        .unwrap_or(false)
+}
+
+#[cfg(any(feature = "wizard", test))]
+fn contains_japanese_text(content: &str) -> bool {
+    content.chars().any(|ch| {
+        matches!(
+            ch,
+            '\u{3040}'..='\u{309f}' | '\u{30a0}'..='\u{30ff}' | '\u{ff66}'..='\u{ff9f}'
+        )
+    })
+}
+
 #[cfg(feature = "wizard")]
 fn run_wizard(file_exists: bool) -> Result<Option<InitAnswers>> {
     // 0. Language Selection
@@ -499,6 +561,13 @@ fn run_wizard(file_exists: bool) -> Result<Option<InitAnswers>> {
     };
 
     println!("{}", t("welcome").bold().cyan());
+    if let Some(preset_id) = infer_wizard_preset(Path::new(".")) {
+        let message = match lang_selection {
+            Language::En => format!("Detected preset candidate: {}", preset_id),
+            Language::Ja => format!("推奨プリセット候補: {}", preset_id),
+        };
+        println!("{}", message.dimmed());
+    }
 
     let mut target_path = None;
 
@@ -738,5 +807,45 @@ mod tests {
             log_pack_rules_dir_for_config(Path::new("configs/veil.logs.toml")),
             PathBuf::from("configs/rules/log")
         );
+    }
+
+    #[test]
+    fn infer_wizard_preset_prefers_logs_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("logs")).unwrap();
+        fs::create_dir(dir.path().join("payments")).unwrap();
+
+        assert_eq!(infer_wizard_preset(dir.path()), Some("logs-jp"));
+    }
+
+    #[test]
+    fn infer_wizard_preset_detects_root_log_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("audit.jsonl"), "{}\n").unwrap();
+
+        assert_eq!(infer_wizard_preset(dir.path()), Some("logs-jp"));
+    }
+
+    #[test]
+    fn infer_wizard_preset_detects_fintech_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("kyc")).unwrap();
+
+        assert_eq!(infer_wizard_preset(dir.path()), Some("fintech-jp"));
+    }
+
+    #[test]
+    fn infer_wizard_preset_detects_japanese_readme() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("README.md"), "これは日本語のREADMEです。\n").unwrap();
+
+        assert_eq!(infer_wizard_preset(dir.path()), Some("standard-jp"));
+    }
+
+    #[test]
+    fn infer_wizard_preset_returns_none_without_signals() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert_eq!(infer_wizard_preset(dir.path()), None);
     }
 }

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -45,7 +45,7 @@ PR分割:
 - [ ] `CoreConfig.preset` 追加（急がない。#106時点ではCLI/Local API引数のbase layer適用を正本とする）
 - [x] `veil init --preset` 実装
 - [x] `veil scan --preset` 実装
-- [ ] wizard推論ロジック
+- [x] wizard推論ロジック（候補検出と表示。自動適用はしない）
 - [x] docs/README更新
 - [x] `veil config dump --preset` 実装
 - [x] Local API / UI の preset対応（#106: Local API scan preset解決 + 最小UI selector。大きなUI workflow改修はPhase 5）

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2529,7 +2529,7 @@ PR分割:
 - [ ] `CoreConfig.preset` 追加（急がない。#106時点ではCLI/Local API引数のbase layer適用を正本とする）
 - [x] `veil init --preset` 実装
 - [x] `veil scan --preset` 実装
-- [ ] wizard推論ロジック
+- [x] wizard推論ロジック（候補検出と表示。自動適用はしない）
 - [x] docs/README更新
 - [x] `veil config dump --preset` 実装
 - [x] Local API / UI の preset対応（#106: Local API scan preset解決 + 最小UI selector。大きなUI workflow改修はPhase 5）

--- a/docs/pr/PR-121-wizard-preset-inference.md
+++ b/docs/pr/PR-121-wizard-preset-inference.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 121
 status: Draft
 created_at: TBD
 branch: feat/wizard-preset-inference
@@ -12,7 +12,7 @@ title: Add wizard preset inference
 ## SOT
 - Title: Add wizard preset inference
 - Status: Draft
-- PR: TBD
+- PR: #121
 
 ## What
 - [x] Add deterministic `veil init --wizard` preset inference for root-level project signals.
@@ -28,7 +28,7 @@ title: Add wizard preset inference
 
 ## Evidence
 - Local test result: `5 passed; 0 failed` for `infer_wizard_preset`.
-- SOT will be renamed from `PR-TBD-wizard-preset-inference.md` after PR creation.
+- SOT was renamed from the temporary PR placeholder name after PR #121 was created.
 
 ## Non-goals
 - [x] Do not add `CoreConfig.preset`.

--- a/docs/pr/PR-TBD-wizard-preset-inference.md
+++ b/docs/pr/PR-TBD-wizard-preset-inference.md
@@ -1,0 +1,39 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/wizard-preset-inference
+commit: c6ef29f30e4af2865a43c54cb4d51724ccd120cc
+title: Add wizard preset inference
+---
+
+## SOT
+- Title: Add wizard preset inference
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add deterministic `veil init --wizard` preset inference for root-level project signals.
+- [x] Detect log audit signals (`logs/`, `*.log`, `*.jsonl`, `*.ndjson`) before fintech directory signals.
+- [x] Detect fintech directory signals (`payments`, `billing`, `kyc`, `account`) before Japanese README signals.
+- [x] Display the detected preset candidate in the wizard without auto-applying it.
+- [x] Cover inference priority and no-signal behavior with unit tests.
+
+## Verification
+- [x] `cargo fmt --all --check`
+- [x] `cargo test -p veil-cli infer_wizard_preset -- --nocapture`
+- [x] `git diff --check`
+
+## Evidence
+- Local test result: `5 passed; 0 failed` for `infer_wizard_preset`.
+- SOT will be renamed from `PR-TBD-wizard-preset-inference.md` after PR creation.
+
+## Non-goals
+- [x] Do not add `CoreConfig.preset`.
+- [x] Do not auto-apply inferred presets from the wizard.
+- [x] Do not redesign the existing wizard profile questions.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- add deterministic preset candidate inference for `veil init --wizard`
- display the detected candidate without auto-applying it
- mark the roadmap item complete with the no-auto-apply boundary

## Verification
- `cargo fmt --all --check`
- `cargo test -p veil-cli infer_wizard_preset -- --nocapture`
- `git diff --check`

### SOT
- docs/pr/PR-121-wizard-preset-inference.md