### PR TITLE
Add interactive scan state machine

### DIFF
--- a/crates/veil-cli/src/commands/interactive_scan.rs
+++ b/crates/veil-cli/src/commands/interactive_scan.rs
@@ -1,0 +1,224 @@
+use anyhow::{bail, Result};
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InteractiveScanPhase {
+    RenderContext,
+    AwaitDecision,
+    Help,
+    WritePreview,
+    ConfirmWrite,
+    Complete,
+    Quit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InteractiveScanAction {
+    ContextRendered,
+    MaskRequested,
+    SkipFinding,
+    IgnoreRuleLine,
+    SkipFile,
+    HelpRequested,
+    HelpDismissed,
+    PreviewRendered,
+    WriteConfirmed,
+    WriteCancelled,
+    QuitRequested,
+}
+
+const SUPPORTED_ACTIONS: [InteractiveScanAction; 11] = [
+    InteractiveScanAction::ContextRendered,
+    InteractiveScanAction::MaskRequested,
+    InteractiveScanAction::SkipFinding,
+    InteractiveScanAction::IgnoreRuleLine,
+    InteractiveScanAction::SkipFile,
+    InteractiveScanAction::HelpRequested,
+    InteractiveScanAction::HelpDismissed,
+    InteractiveScanAction::PreviewRendered,
+    InteractiveScanAction::WriteConfirmed,
+    InteractiveScanAction::WriteCancelled,
+    InteractiveScanAction::QuitRequested,
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InteractiveScanState {
+    current_index: usize,
+    total_findings: usize,
+    phase: InteractiveScanPhase,
+}
+
+#[allow(dead_code)]
+impl InteractiveScanState {
+    pub fn new(total_findings: usize) -> Self {
+        let phase = if total_findings == 0 {
+            InteractiveScanPhase::Complete
+        } else {
+            InteractiveScanPhase::RenderContext
+        };
+
+        Self {
+            current_index: 0,
+            total_findings,
+            phase,
+        }
+    }
+
+    pub fn phase(&self) -> InteractiveScanPhase {
+        self.phase
+    }
+
+    pub fn position(&self) -> Option<(usize, usize)> {
+        if self.total_findings == 0 || matches!(self.phase, InteractiveScanPhase::Complete) {
+            None
+        } else {
+            Some((self.current_index + 1, self.total_findings))
+        }
+    }
+
+    pub fn apply(&mut self, action: InteractiveScanAction) -> Result<()> {
+        if action == InteractiveScanAction::QuitRequested
+            && !matches!(self.phase, InteractiveScanPhase::Complete)
+        {
+            self.phase = InteractiveScanPhase::Quit;
+            return Ok(());
+        }
+
+        match (self.phase, action) {
+            (InteractiveScanPhase::RenderContext, InteractiveScanAction::ContextRendered) => {
+                self.phase = InteractiveScanPhase::AwaitDecision;
+            }
+            (InteractiveScanPhase::AwaitDecision, InteractiveScanAction::MaskRequested) => {
+                self.phase = InteractiveScanPhase::WritePreview;
+            }
+            (InteractiveScanPhase::AwaitDecision, InteractiveScanAction::SkipFinding)
+            | (InteractiveScanPhase::AwaitDecision, InteractiveScanAction::IgnoreRuleLine)
+            | (InteractiveScanPhase::AwaitDecision, InteractiveScanAction::SkipFile) => {
+                self.advance_finding();
+            }
+            (InteractiveScanPhase::AwaitDecision, InteractiveScanAction::HelpRequested) => {
+                self.phase = InteractiveScanPhase::Help;
+            }
+            (InteractiveScanPhase::Help, InteractiveScanAction::HelpDismissed) => {
+                self.phase = InteractiveScanPhase::AwaitDecision;
+            }
+            (InteractiveScanPhase::WritePreview, InteractiveScanAction::PreviewRendered) => {
+                self.phase = InteractiveScanPhase::ConfirmWrite;
+            }
+            (InteractiveScanPhase::ConfirmWrite, InteractiveScanAction::WriteConfirmed) => {
+                self.advance_finding();
+            }
+            (InteractiveScanPhase::ConfirmWrite, InteractiveScanAction::WriteCancelled) => {
+                self.phase = InteractiveScanPhase::AwaitDecision;
+            }
+            _ => bail!(
+                "invalid interactive transition: {:?} from {:?}",
+                action,
+                self.phase
+            ),
+        }
+
+        Ok(())
+    }
+
+    fn advance_finding(&mut self) {
+        if self.current_index + 1 >= self.total_findings {
+            self.phase = InteractiveScanPhase::Complete;
+        } else {
+            self.current_index += 1;
+            self.phase = InteractiveScanPhase::RenderContext;
+        }
+    }
+}
+
+pub fn supported_actions() -> &'static [InteractiveScanAction] {
+    &SUPPORTED_ACTIONS
+}
+
+pub fn run_guarded_until_renderer_lands(total_findings: usize) -> Result<bool> {
+    let state = InteractiveScanState::new(total_findings);
+    if matches!(state.phase(), InteractiveScanPhase::Complete) {
+        return Ok(false);
+    }
+
+    bail!(
+        "--interactive initialized finding iteration state at {:?} for {} finding(s), but terminal rendering is not implemented yet. Supported actions: {}.",
+        state.position(),
+        total_findings,
+        supported_actions().len()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_starts_complete_without_findings() {
+        let state = InteractiveScanState::new(0);
+
+        assert_eq!(state.phase(), InteractiveScanPhase::Complete);
+        assert_eq!(state.position(), None);
+    }
+
+    #[test]
+    fn state_skips_findings_until_complete() {
+        let mut state = InteractiveScanState::new(2);
+
+        assert_eq!(state.phase(), InteractiveScanPhase::RenderContext);
+        assert_eq!(state.position(), Some((1, 2)));
+
+        state.apply(InteractiveScanAction::ContextRendered).unwrap();
+        state.apply(InteractiveScanAction::SkipFinding).unwrap();
+        assert_eq!(state.phase(), InteractiveScanPhase::RenderContext);
+        assert_eq!(state.position(), Some((2, 2)));
+
+        state.apply(InteractiveScanAction::ContextRendered).unwrap();
+        state.apply(InteractiveScanAction::SkipFinding).unwrap();
+        assert_eq!(state.phase(), InteractiveScanPhase::Complete);
+        assert_eq!(state.position(), None);
+    }
+
+    #[test]
+    fn state_masks_after_preview_confirmation() {
+        let mut state = InteractiveScanState::new(1);
+
+        state.apply(InteractiveScanAction::ContextRendered).unwrap();
+        state.apply(InteractiveScanAction::MaskRequested).unwrap();
+        assert_eq!(state.phase(), InteractiveScanPhase::WritePreview);
+
+        state.apply(InteractiveScanAction::PreviewRendered).unwrap();
+        assert_eq!(state.phase(), InteractiveScanPhase::ConfirmWrite);
+
+        state.apply(InteractiveScanAction::WriteConfirmed).unwrap();
+        assert_eq!(state.phase(), InteractiveScanPhase::Complete);
+    }
+
+    #[test]
+    fn state_returns_from_help_to_decision() {
+        let mut state = InteractiveScanState::new(1);
+
+        state.apply(InteractiveScanAction::ContextRendered).unwrap();
+        state.apply(InteractiveScanAction::HelpRequested).unwrap();
+        assert_eq!(state.phase(), InteractiveScanPhase::Help);
+
+        state.apply(InteractiveScanAction::HelpDismissed).unwrap();
+        assert_eq!(state.phase(), InteractiveScanPhase::AwaitDecision);
+    }
+
+    #[test]
+    fn state_rejects_invalid_transition() {
+        let mut state = InteractiveScanState::new(1);
+
+        let err = state
+            .apply(InteractiveScanAction::WriteConfirmed)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid interactive transition"));
+    }
+
+    #[test]
+    fn guarded_runner_succeeds_without_findings() {
+        assert!(!run_guarded_until_renderer_lands(0).unwrap());
+    }
+}

--- a/crates/veil-cli/src/commands/mod.rs
+++ b/crates/veil-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod git;
 pub mod guardian;
 pub mod ignore;
 pub mod init;
+pub mod interactive_scan;
 pub mod mask;
 pub mod pre_commit;
 pub mod rules;

--- a/crates/veil-cli/src/commands/scan.rs
+++ b/crates/veil-cli/src/commands/scan.rs
@@ -451,12 +451,6 @@ pub fn scan(
     if fail_score.is_some_and(|score| score > 100) {
         anyhow::bail!("--fail-on-score must be between 0 and 100");
     }
-    if interactive {
-        anyhow::bail!(
-            "--interactive is accepted but not implemented yet. Use `veil scan` for read-only scanning; interactive masking will land behind this explicit flag."
-        );
-    }
-
     if show_progress {
         eprintln!("Scanning...");
     }
@@ -491,6 +485,12 @@ pub fn scan(
         limit,
         baseline.as_ref(),
     )?;
+
+    if interactive {
+        return crate::commands::interactive_scan::run_guarded_until_renderer_lands(
+            result.findings.len(),
+        );
+    }
 
     // Handle Write Baseline (S26)
     if let Some(path) = &write_baseline {

--- a/crates/veil-cli/tests/exit_code_test.rs
+++ b/crates/veil-cli/tests/exit_code_test.rs
@@ -46,6 +46,11 @@ fn test_exit_code_behavior() {
 #[test]
 fn scan_interactive_flag_is_guarded_until_state_machine_lands() {
     let temp_dir = tempdir().unwrap();
+    fs::write(
+        temp_dir.path().join("secret.txt"),
+        "AWS_ACCESS_KEY_ID = \"AKIAIOSFODNN7EXAMPLE\"",
+    )
+    .unwrap();
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
     cmd.arg("scan")
@@ -55,6 +60,6 @@ fn scan_interactive_flag_is_guarded_until_state_machine_lands() {
         .failure()
         .code(2)
         .stderr(predicate::str::contains(
-            "--interactive is accepted but not implemented yet",
+            "--interactive initialized finding iteration state",
         ));
 }

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -53,7 +53,7 @@ PR分割:
 ## Phase 3: Interactive CLI
 
 - [x] `veil scan --interactive` flag（guarded stub）
-- [ ] Finding iteration state machine
+- [x] Finding iteration state machine（renderer 未接続）
 - [ ] terminal rendering
 - [ ] diff preview
 - [ ] atomic write

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2537,7 +2537,7 @@ PR分割:
 ## Phase 3: Interactive CLI
 
 - [x] `veil scan --interactive` flag（guarded stub）
-- [ ] Finding iteration state machine
+- [x] Finding iteration state machine（renderer 未接続）
 - [ ] terminal rendering
 - [ ] diff preview
 - [ ] atomic write

--- a/docs/pr/PR-123-interactive-state-machine.md
+++ b/docs/pr/PR-123-interactive-state-machine.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 123
 status: Draft
 created_at: TBD
 branch: feat/interactive-state-machine
@@ -12,7 +12,7 @@ title: Add interactive scan state machine
 ## SOT
 - Title: Add interactive scan state machine
 - Status: Draft
-- PR: TBD
+- PR: #123
 
 ## What
 - [x] Add an `interactive_scan` state machine for Phase 3 interactive scan flow.
@@ -31,7 +31,7 @@ title: Add interactive scan state machine
 ## Evidence
 - Local state-machine test result: `6 passed; 0 failed` for `interactive_scan`.
 - Local guarded integration test result: `1 passed; 0 failed`.
-- SOT will be renamed after PR creation.
+- SOT was renamed after PR #123 was created.
 
 ## Non-goals
 - [x] Do not implement terminal rendering.

--- a/docs/pr/PR-TBD-interactive-state-machine.md
+++ b/docs/pr/PR-TBD-interactive-state-machine.md
@@ -1,0 +1,43 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/interactive-state-machine
+commit: 08121a11a6be8b6835bc9fc4b6edf19e0c42bdda
+title: Add interactive scan state machine
+---
+
+## SOT
+- Title: Add interactive scan state machine
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add an `interactive_scan` state machine for Phase 3 interactive scan flow.
+- [x] Model context rendering, decision wait, help, write preview, write confirmation, completion, and quit phases.
+- [x] Model supported decisions for mask, skip finding, ignore rule line, skip file, help, confirm/cancel write, and quit.
+- [x] Initialize the state machine from `veil scan --interactive` scan results.
+- [x] Keep terminal rendering guarded until the next PR.
+- [x] Mark the roadmap state-machine task complete with the renderer boundary.
+
+## Verification
+- [x] `cargo fmt --all --check`
+- [x] `cargo test -p veil-cli interactive_scan -- --nocapture`
+- [x] `cargo test -p veil-cli scan_interactive_flag_is_guarded_until_state_machine_lands -- --nocapture`
+- [x] `git diff --check`
+
+## Evidence
+- Local state-machine test result: `6 passed; 0 failed` for `interactive_scan`.
+- Local guarded integration test result: `1 passed; 0 failed`.
+- SOT will be renamed after PR creation.
+
+## Non-goals
+- [x] Do not implement terminal rendering.
+- [x] Do not implement diff preview.
+- [x] Do not implement atomic writes or file mutation.
+- [x] Do not change normal non-interactive `veil scan` output.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- add a tested interactive scan state machine for finding iteration
- initialize the state machine from `veil scan --interactive` results
- keep terminal rendering guarded for the next PR

## Verification
- `cargo fmt --all --check`
- `cargo test -p veil-cli interactive_scan -- --nocapture`
- `cargo test -p veil-cli scan_interactive_flag_is_guarded_until_state_machine_lands -- --nocapture`
- `git diff --check`

### SOT
- docs/pr/PR-123-interactive-state-machine.md