### PR TITLE
Add interactive terminal rendering

### DIFF
--- a/crates/veil-cli/src/commands/interactive_scan.rs
+++ b/crates/veil-cli/src/commands/interactive_scan.rs
@@ -1,4 +1,6 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use std::io::{self, Write};
+use veil_core::Finding;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +78,14 @@ impl InteractiveScanState {
         }
     }
 
+    pub fn current_index(&self) -> Option<usize> {
+        if self.total_findings == 0 || matches!(self.phase, InteractiveScanPhase::Complete) {
+            None
+        } else {
+            Some(self.current_index)
+        }
+    }
+
     pub fn apply(&mut self, action: InteractiveScanAction) -> Result<()> {
         if action == InteractiveScanAction::QuitRequested
             && !matches!(self.phase, InteractiveScanPhase::Complete)
@@ -135,16 +145,56 @@ pub fn supported_actions() -> &'static [InteractiveScanAction] {
     &SUPPORTED_ACTIONS
 }
 
-pub fn run_guarded_until_renderer_lands(total_findings: usize) -> Result<bool> {
-    let state = InteractiveScanState::new(total_findings);
+pub fn render_finding_context<W: Write>(
+    writer: &mut W,
+    state: &InteractiveScanState,
+    finding: &Finding,
+) -> io::Result<()> {
+    let Some((position, total)) = state.position() else {
+        return Ok(());
+    };
+
+    writeln!(writer, "Finding {}/{}", position, total)?;
+    writeln!(writer, "Rule: {}", finding.rule_id)?;
+    writeln!(
+        writer,
+        "File: {}:{}",
+        finding.path.display(),
+        finding.line_number
+    )?;
+    writeln!(
+        writer,
+        "Severity: {}  Score: {}  Grade: {}",
+        finding.severity, finding.score, finding.grade
+    )?;
+    writeln!(writer, "Snippet:")?;
+    writeln!(writer, "{}", finding.masked_snippet.trim())?;
+    writeln!(writer)?;
+    writeln!(
+        writer,
+        "Action: mask / skip / ignore-line / skip-file / help / quit"
+    )?;
+    Ok(())
+}
+
+pub fn run_guarded_until_decision_input_lands(findings: &[Finding]) -> Result<bool> {
+    let mut state = InteractiveScanState::new(findings.len());
     if matches!(state.phase(), InteractiveScanPhase::Complete) {
         return Ok(false);
     }
 
+    if let Some(index) = state.current_index() {
+        let stdout = io::stdout();
+        let mut writer = stdout.lock();
+        render_finding_context(&mut writer, &state, &findings[index])
+            .context("render interactive finding context")?;
+    }
+    state.apply(InteractiveScanAction::ContextRendered)?;
+
     bail!(
-        "--interactive initialized finding iteration state at {:?} for {} finding(s), but terminal rendering is not implemented yet. Supported actions: {}.",
+        "--interactive rendered finding context at {:?} for {} finding(s), but decision input is not implemented yet. Supported actions: {}.",
         state.position(),
-        total_findings,
+        findings.len(),
         supported_actions().len()
     )
 }
@@ -152,6 +202,8 @@ pub fn run_guarded_until_renderer_lands(total_findings: usize) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+    use veil_core::{FindingSpan, Grade, Position, Range, Severity};
 
     #[test]
     fn state_starts_complete_without_findings() {
@@ -219,6 +271,53 @@ mod tests {
 
     #[test]
     fn guarded_runner_succeeds_without_findings() {
-        assert!(!run_guarded_until_renderer_lands(0).unwrap());
+        assert!(!run_guarded_until_decision_input_lands(&[]).unwrap());
+    }
+
+    #[test]
+    fn renderer_prints_safe_finding_context() {
+        let state = InteractiveScanState::new(1);
+        let finding = test_finding();
+        let mut output = Vec::new();
+
+        render_finding_context(&mut output, &state, &finding).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+
+        assert!(rendered.contains("Finding 1/1"));
+        assert!(rendered.contains("Rule: pii.test"));
+        assert!(rendered.contains("File: src/main.rs:42"));
+        assert!(rendered.contains("Severity: HIGH  Score: 90  Grade: CRITICAL"));
+        assert!(rendered.contains("token = <REDACTED>"));
+        assert!(!rendered.contains("raw-secret-value"));
+    }
+
+    fn test_finding() -> Finding {
+        Finding {
+            path: PathBuf::from("src/main.rs"),
+            line_number: 42,
+            line_content: "token = raw-secret-value".to_string(),
+            rule_id: "pii.test".to_string(),
+            matched_content: "raw-secret-value".to_string(),
+            masked_snippet: "token = <REDACTED>".to_string(),
+            severity: Severity::High,
+            score: 90,
+            grade: Grade::Critical,
+            span: FindingSpan::default(),
+            utf16_range: Range {
+                start: Position {
+                    line: 41,
+                    character: 8,
+                },
+                end: Position {
+                    line: 41,
+                    character: 24,
+                },
+            },
+            context_before: vec![],
+            context_after: vec![],
+            commit_sha: None,
+            author: None,
+            date: None,
+        }
     }
 }

--- a/crates/veil-cli/src/commands/scan.rs
+++ b/crates/veil-cli/src/commands/scan.rs
@@ -487,8 +487,8 @@ pub fn scan(
     )?;
 
     if interactive {
-        return crate::commands::interactive_scan::run_guarded_until_renderer_lands(
-            result.findings.len(),
+        return crate::commands::interactive_scan::run_guarded_until_decision_input_lands(
+            &result.findings,
         );
     }
 

--- a/crates/veil-cli/tests/exit_code_test.rs
+++ b/crates/veil-cli/tests/exit_code_test.rs
@@ -44,7 +44,7 @@ fn test_exit_code_behavior() {
 }
 
 #[test]
-fn scan_interactive_flag_is_guarded_until_state_machine_lands() {
+fn scan_interactive_renders_first_finding_until_decision_input_lands() {
     let temp_dir = tempdir().unwrap();
     fs::write(
         temp_dir.path().join("secret.txt"),
@@ -59,7 +59,12 @@ fn scan_interactive_flag_is_guarded_until_state_machine_lands() {
         .assert()
         .failure()
         .code(2)
+        .stdout(
+            predicate::str::contains("Finding 1/")
+                .and(predicate::str::contains("Snippet:"))
+                .and(predicate::str::contains("<REDACTED>")),
+        )
         .stderr(predicate::str::contains(
-            "--interactive initialized finding iteration state",
+            "--interactive rendered finding context",
         ));
 }

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -54,7 +54,7 @@ PR分割:
 
 - [x] `veil scan --interactive` flag（guarded stub）
 - [x] Finding iteration state machine（renderer 未接続）
-- [ ] terminal rendering
+- [x] terminal rendering（safe masked context）
 - [ ] diff preview
 - [ ] atomic write
 - [ ] tests with scripted stdin

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2538,7 +2538,7 @@ PR分割:
 
 - [x] `veil scan --interactive` flag（guarded stub）
 - [x] Finding iteration state machine（renderer 未接続）
-- [ ] terminal rendering
+- [x] terminal rendering（safe masked context）
 - [ ] diff preview
 - [ ] atomic write
 - [ ] tests with scripted stdin

--- a/docs/pr/PR-124-interactive-terminal-rendering.md
+++ b/docs/pr/PR-124-interactive-terminal-rendering.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 124
 status: Draft
 created_at: TBD
 branch: feat/interactive-terminal-rendering
@@ -12,7 +12,7 @@ title: Add interactive terminal rendering
 ## SOT
 - Title: Add interactive terminal rendering
 - Status: Draft
-- PR: TBD
+- PR: #124
 
 ## What
 - [x] Add terminal rendering for the current `veil scan --interactive` finding.
@@ -32,7 +32,7 @@ title: Add interactive terminal rendering
 - Local interactive unit test result: `7 passed; 0 failed`.
 - Local guarded integration test result: `1 passed; 0 failed`.
 - Unit coverage asserts the rendered terminal context contains `<REDACTED>` and does not contain the raw matched value.
-- SOT will be renamed after PR creation.
+- SOT was renamed after PR #124 was created.
 
 ## Non-goals
 - [x] Do not implement decision input.

--- a/docs/pr/PR-TBD-interactive-terminal-rendering.md
+++ b/docs/pr/PR-TBD-interactive-terminal-rendering.md
@@ -1,0 +1,44 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/interactive-terminal-rendering
+commit: 0b6e50e5b7c7fd72778b3519f5a5dcccbdf59ab6
+title: Add interactive terminal rendering
+---
+
+## SOT
+- Title: Add interactive terminal rendering
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add terminal rendering for the current `veil scan --interactive` finding.
+- [x] Render only safe context: position, rule id, path, line, severity, score, grade, and `masked_snippet`.
+- [x] Keep raw `line_content` and `matched_content` out of interactive output.
+- [x] Advance the state machine from `RenderContext` to `AwaitDecision` after rendering.
+- [x] Keep decision input guarded for a follow-up PR.
+- [x] Mark the roadmap terminal rendering task complete with the safe masked-context boundary.
+
+## Verification
+- [x] `cargo fmt --all --check`
+- [x] `cargo test -p veil-cli interactive_scan -- --nocapture`
+- [x] `cargo test -p veil-cli scan_interactive_renders_first_finding_until_decision_input_lands -- --nocapture`
+- [x] `git diff --check`
+
+## Evidence
+- Local interactive unit test result: `7 passed; 0 failed`.
+- Local guarded integration test result: `1 passed; 0 failed`.
+- Unit coverage asserts the rendered terminal context contains `<REDACTED>` and does not contain the raw matched value.
+- SOT will be renamed after PR creation.
+
+## Non-goals
+- [x] Do not implement decision input.
+- [x] Do not implement diff preview.
+- [x] Do not implement atomic writes or file mutation.
+- [x] Do not print raw secret values.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- render safe terminal context for the current `veil scan --interactive` finding
- print only masked snippets and metadata, not raw matched content
- keep decision input guarded for the next PR

## Verification
- `cargo fmt --all --check`
- `cargo test -p veil-cli interactive_scan -- --nocapture`
- `cargo test -p veil-cli scan_interactive_renders_first_finding_until_decision_input_lands -- --nocapture`
- `git diff --check`

### SOT
- docs/pr/PR-124-interactive-terminal-rendering.md