### PR TITLE
Add interactive diff preview

### DIFF
--- a/crates/veil-cli/src/commands/interactive_scan.rs
+++ b/crates/veil-cli/src/commands/interactive_scan.rs
@@ -169,12 +169,32 @@ pub fn render_finding_context<W: Write>(
     )?;
     writeln!(writer, "Snippet:")?;
     writeln!(writer, "{}", finding.masked_snippet.trim())?;
+    render_mask_preview(writer, finding)?;
     writeln!(writer)?;
     writeln!(
         writer,
         "Action: mask / skip / ignore-line / skip-file / help / quit"
     )?;
     Ok(())
+}
+
+pub fn render_mask_preview<W: Write>(writer: &mut W, finding: &Finding) -> io::Result<()> {
+    writeln!(writer, "Mask preview:")?;
+    writeln!(writer, "- {}", safe_before_line(finding))?;
+    writeln!(writer, "+ {}", finding.masked_snippet.trim())?;
+    Ok(())
+}
+
+fn safe_before_line(finding: &Finding) -> String {
+    if finding.matched_content.is_empty()
+        || !finding.line_content.contains(&finding.matched_content)
+    {
+        return "<sensitive content hidden>".to_string();
+    }
+
+    finding
+        .line_content
+        .replacen(&finding.matched_content, "<MATCH>", 1)
 }
 
 pub fn run_guarded_until_decision_input_lands(findings: &[Finding]) -> Result<bool> {
@@ -288,7 +308,25 @@ mod tests {
         assert!(rendered.contains("File: src/main.rs:42"));
         assert!(rendered.contains("Severity: HIGH  Score: 90  Grade: CRITICAL"));
         assert!(rendered.contains("token = <REDACTED>"));
+        assert!(rendered.contains("Mask preview:"));
+        assert!(rendered.contains("- token = <MATCH>"));
+        assert!(rendered.contains("+ token = <REDACTED>"));
         assert!(!rendered.contains("raw-secret-value"));
+    }
+
+    #[test]
+    fn mask_preview_hides_unmatched_raw_content() {
+        let mut finding = test_finding();
+        finding.matched_content = "different-raw-value".to_string();
+        let mut output = Vec::new();
+
+        render_mask_preview(&mut output, &finding).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+
+        assert!(rendered.contains("- <sensitive content hidden>"));
+        assert!(rendered.contains("+ token = <REDACTED>"));
+        assert!(!rendered.contains("raw-secret-value"));
+        assert!(!rendered.contains("different-raw-value"));
     }
 
     fn test_finding() -> Finding {

--- a/crates/veil-cli/tests/exit_code_test.rs
+++ b/crates/veil-cli/tests/exit_code_test.rs
@@ -62,6 +62,7 @@ fn scan_interactive_renders_first_finding_until_decision_input_lands() {
         .stdout(
             predicate::str::contains("Finding 1/")
                 .and(predicate::str::contains("Snippet:"))
+                .and(predicate::str::contains("Mask preview:"))
                 .and(predicate::str::contains("<REDACTED>")),
         )
         .stderr(predicate::str::contains(

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -55,7 +55,7 @@ PR分割:
 - [x] `veil scan --interactive` flag（guarded stub）
 - [x] Finding iteration state machine（renderer 未接続）
 - [x] terminal rendering（safe masked context）
-- [ ] diff preview
+- [x] diff preview（safe redacted preview）
 - [ ] atomic write
 - [ ] tests with scripted stdin
 

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2539,7 +2539,7 @@ PR分割:
 - [x] `veil scan --interactive` flag（guarded stub）
 - [x] Finding iteration state machine（renderer 未接続）
 - [x] terminal rendering（safe masked context）
-- [ ] diff preview
+- [x] diff preview（safe redacted preview）
 - [ ] atomic write
 - [ ] tests with scripted stdin
 

--- a/docs/pr/PR-125-interactive-diff-preview.md
+++ b/docs/pr/PR-125-interactive-diff-preview.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 125
 status: Draft
 created_at: TBD
 branch: feat/interactive-diff-preview
@@ -12,7 +12,7 @@ title: Add interactive diff preview
 ## SOT
 - Title: Add interactive diff preview
 - Status: Draft
-- PR: TBD
+- PR: #125
 
 ## What
 - [x] Add a safe `Mask preview` block to interactive terminal rendering.
@@ -31,7 +31,7 @@ title: Add interactive diff preview
 - Local interactive unit test result: `8 passed; 0 failed`.
 - Local guarded integration test result: `1 passed; 0 failed`.
 - Unit coverage asserts unmatched raw content is hidden and raw matched values do not appear in preview output.
-- SOT will be renamed after PR creation.
+- SOT was renamed after PR #125 was created.
 
 ## Non-goals
 - [x] Do not implement decision input.

--- a/docs/pr/PR-TBD-interactive-diff-preview.md
+++ b/docs/pr/PR-TBD-interactive-diff-preview.md
@@ -1,0 +1,42 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/interactive-diff-preview
+commit: 3c27b450ab8c563dfb496f826d4a50e7f38b3a47
+title: Add interactive diff preview
+---
+
+## SOT
+- Title: Add interactive diff preview
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add a safe `Mask preview` block to interactive terminal rendering.
+- [x] Render before/after lines as `- <MATCH>` redacted source and `+ <REDACTED>` masked output.
+- [x] Hide raw content when the matched raw value cannot be located in the source line.
+- [x] Keep the interactive state at decision input; do not auto-select mask.
+- [x] Mark the Phase 3 diff preview task complete with the safe redacted-preview boundary.
+
+## Verification
+- [x] `cargo fmt --all --check`
+- [x] `cargo test -p veil-cli interactive_scan -- --nocapture`
+- [x] `cargo test -p veil-cli scan_interactive_renders_first_finding_until_decision_input_lands -- --nocapture`
+- [x] `git diff --check`
+
+## Evidence
+- Local interactive unit test result: `8 passed; 0 failed`.
+- Local guarded integration test result: `1 passed; 0 failed`.
+- Unit coverage asserts unmatched raw content is hidden and raw matched values do not appear in preview output.
+- SOT will be renamed after PR creation.
+
+## Non-goals
+- [x] Do not implement decision input.
+- [x] Do not implement atomic writes or file mutation.
+- [x] Do not display raw secret values.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- add a safe mask preview block to interactive terminal output
- redact before-lines with `<MATCH>` and after-lines with existing masked snippets
- keep decision input and writes out of scope

## Verification
- `cargo fmt --all --check`
- `cargo test -p veil-cli interactive_scan -- --nocapture`
- `cargo test -p veil-cli scan_interactive_renders_first_finding_until_decision_input_lands -- --nocapture`
- `git diff --check`

### SOT
- docs/pr/PR-125-interactive-diff-preview.md