### PR TITLE
Add interactive atomic write

### DIFF
--- a/crates/veil-cli/Cargo.toml
+++ b/crates/veil-cli/Cargo.toml
@@ -38,12 +38,12 @@ regex = "1.12.2"
 toml_edit = "0.22"
 ctrlc = "3.5.1"
 rust-embed = "8.5"
+tempfile = "3.10"
 
 [dev-dependencies]
 trycmd = "0.15"
 assert_cmd = "2.0"
 predicates = "3.1"
-tempfile = "3.10"
 fs2 = { workspace = true }
 zip = "5.0.1"
 hex = "0.4.3"

--- a/crates/veil-cli/src/commands/interactive_scan.rs
+++ b/crates/veil-cli/src/commands/interactive_scan.rs
@@ -1,5 +1,7 @@
 use anyhow::{bail, Context, Result};
+use std::fs;
 use std::io::{self, BufRead, Write};
+use std::path::Path;
 use veil_core::Finding;
 
 #[allow(dead_code)]
@@ -275,8 +277,22 @@ pub fn run_with_io<R: BufRead, W: Write>(
                 state.apply(InteractiveScanAction::HelpDismissed)?;
             }
             Some(InteractiveDecision::Mask) => {
+                let Some(index) = state.current_index() else {
+                    return Ok(false);
+                };
                 state.apply(InteractiveScanAction::MaskRequested)?;
-                bail!("--interactive action 'mask' is parsed but write handling is not implemented yet");
+                state.apply(InteractiveScanAction::PreviewRendered)?;
+                let wrote = apply_mask_atomic(&findings[index])?;
+                if wrote {
+                    writeln!(output, "Masked: {}", findings[index].path.display())?;
+                } else {
+                    writeln!(output, "Already masked: {}", findings[index].path.display())?;
+                }
+                output.flush().context("flush interactive mask result")?;
+                state.apply(InteractiveScanAction::WriteConfirmed)?;
+                if matches!(state.phase(), InteractiveScanPhase::Complete) {
+                    return Ok(false);
+                }
             }
             Some(InteractiveDecision::IgnoreRuleLine) => {
                 bail!(
@@ -302,9 +318,120 @@ pub fn run_with_io<R: BufRead, W: Write>(
     }
 }
 
+fn apply_mask_atomic(finding: &Finding) -> Result<bool> {
+    if finding.matched_content.is_empty() {
+        bail!("cannot mask finding with empty matched content");
+    }
+
+    if finding.masked_snippet.contains('\n') || finding.masked_snippet.contains('\r') {
+        bail!("cannot mask finding with multi-line masked snippet");
+    }
+
+    let content = fs::read_to_string(&finding.path)
+        .with_context(|| format!("read {}", finding.path.display()))?;
+    let Some(new_content) = masked_file_content(&content, finding)? else {
+        return Ok(false);
+    };
+
+    write_atomic(&finding.path, &new_content)?;
+    Ok(true)
+}
+
+fn masked_file_content(content: &str, finding: &Finding) -> Result<Option<String>> {
+    let Some(target_index) = finding.line_number.checked_sub(1) else {
+        bail!("finding line number must be 1-based");
+    };
+
+    let mut output = String::with_capacity(content.len());
+    let mut found_target = false;
+
+    for (index, segment) in content.split_inclusive('\n').enumerate() {
+        if index != target_index {
+            output.push_str(segment);
+            continue;
+        }
+
+        found_target = true;
+        let (line, ending) = split_line_ending(segment);
+
+        if line == finding.masked_snippet {
+            return Ok(None);
+        }
+
+        if line != finding.line_content {
+            bail!(
+                "refusing to mask {}:{} because the line changed since scan",
+                finding.path.display(),
+                finding.line_number
+            );
+        }
+
+        if !line.contains(&finding.matched_content) {
+            bail!(
+                "refusing to mask {}:{} because matched content is no longer present",
+                finding.path.display(),
+                finding.line_number
+            );
+        }
+
+        output.push_str(&finding.masked_snippet);
+        output.push_str(ending);
+    }
+
+    if !found_target {
+        bail!(
+            "refusing to mask {}:{} because the line was not found",
+            finding.path.display(),
+            finding.line_number
+        );
+    }
+
+    Ok(Some(output))
+}
+
+fn split_line_ending(segment: &str) -> (&str, &str) {
+    if let Some(line) = segment.strip_suffix("\r\n") {
+        (line, "\r\n")
+    } else if let Some(line) = segment.strip_suffix('\n') {
+        (line, "\n")
+    } else {
+        (segment, "")
+    }
+}
+
+fn write_atomic(path: &Path, content: &str) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let permissions = fs::metadata(path)
+        .with_context(|| format!("read metadata for {}", path.display()))?
+        .permissions();
+    let mut tmp = tempfile::Builder::new()
+        .prefix(".veil-interactive-mask.")
+        .tempfile_in(parent)
+        .with_context(|| format!("create temp file in {}", parent.display()))?;
+
+    tmp.write_all(content.as_bytes())
+        .with_context(|| format!("write temp file for {}", path.display()))?;
+    tmp.flush()
+        .with_context(|| format!("flush temp file for {}", path.display()))?;
+    fs::set_permissions(tmp.path(), permissions)
+        .with_context(|| format!("set temp file permissions for {}", tmp.path().display()))?;
+    tmp.as_file()
+        .sync_all()
+        .with_context(|| format!("sync temp file for {}", path.display()))?;
+    tmp.persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("replace {}", path.display()))?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::path::PathBuf;
     use veil_core::{FindingSpan, Grade, Position, Range, Severity};
 
@@ -443,16 +570,55 @@ mod tests {
     }
 
     #[test]
-    fn runner_guards_mask_until_write_lands() {
-        let findings = vec![test_finding()];
+    fn runner_masks_scripted_decision_with_atomic_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.txt");
+        fs::write(&path, "token = raw-secret-value\nnext = safe\n").unwrap();
+        let findings = vec![test_finding_at(path.clone())];
         let mut input = io::Cursor::new(b"mask\n".to_vec());
         let mut output = Vec::new();
 
-        let err = run_with_io(&findings, &mut input, &mut output)
-            .unwrap_err()
-            .to_string();
+        assert!(!run_with_io(&findings, &mut input, &mut output).unwrap());
+        let rendered = String::from_utf8(output).unwrap();
 
-        assert!(err.contains("write handling is not implemented yet"));
+        assert!(rendered.contains("Masked:"));
+        assert_eq!(
+            fs::read_to_string(path).unwrap(),
+            "token = <REDACTED>\nnext = safe\n"
+        );
+    }
+
+    #[test]
+    fn atomic_mask_rejects_stale_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.txt");
+        fs::write(&path, "token = changed-value\n").unwrap();
+        let finding = test_finding_at(path.clone());
+
+        let err = apply_mask_atomic(&finding).unwrap_err().to_string();
+
+        assert!(err.contains("line changed since scan"));
+        assert_eq!(fs::read_to_string(path).unwrap(), "token = changed-value\n");
+    }
+
+    #[test]
+    fn atomic_mask_preserves_crlf_line_endings() {
+        let finding = test_finding();
+
+        let masked = masked_file_content("token = raw-secret-value\r\nnext = safe\r\n", &finding)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(masked, "token = <REDACTED>\r\nnext = safe\r\n");
+    }
+
+    #[test]
+    fn atomic_mask_is_idempotent_for_already_masked_line() {
+        let finding = test_finding();
+
+        assert!(masked_file_content("token = <REDACTED>\n", &finding)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -466,7 +632,7 @@ mod tests {
 
         assert!(rendered.contains("Finding 1/1"));
         assert!(rendered.contains("Rule: pii.test"));
-        assert!(rendered.contains("File: src/main.rs:42"));
+        assert!(rendered.contains("File: src/main.rs:1"));
         assert!(rendered.contains("Severity: HIGH  Score: 90  Grade: CRITICAL"));
         assert!(rendered.contains("token = <REDACTED>"));
         assert!(rendered.contains("Mask preview:"));
@@ -491,9 +657,13 @@ mod tests {
     }
 
     fn test_finding() -> Finding {
+        test_finding_at(PathBuf::from("src/main.rs"))
+    }
+
+    fn test_finding_at(path: PathBuf) -> Finding {
         Finding {
-            path: PathBuf::from("src/main.rs"),
-            line_number: 42,
+            path,
+            line_number: 1,
             line_content: "token = raw-secret-value".to_string(),
             rule_id: "pii.test".to_string(),
             matched_content: "raw-secret-value".to_string(),
@@ -504,11 +674,11 @@ mod tests {
             span: FindingSpan::default(),
             utf16_range: Range {
                 start: Position {
-                    line: 41,
+                    line: 0,
                     character: 8,
                 },
                 end: Position {
-                    line: 41,
+                    line: 0,
                     character: 24,
                 },
             },

--- a/crates/veil-cli/tests/exit_code_test.rs
+++ b/crates/veil-cli/tests/exit_code_test.rs
@@ -67,3 +67,28 @@ fn scan_interactive_accepts_scripted_quit() {
         )
         .stderr(predicate::str::is_empty());
 }
+
+#[test]
+fn scan_interactive_masks_with_scripted_input() {
+    let temp_dir = tempdir().unwrap();
+    let secret_path = temp_dir.path().join("secret.txt");
+    fs::write(
+        &secret_path,
+        "AWS_ACCESS_KEY_ID = \"AKIAIOSFODNN7EXAMPLE\"\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_veil"));
+    cmd.arg("scan")
+        .arg("--interactive")
+        .arg(temp_dir.path())
+        .write_stdin("mask\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Masked:"))
+        .stderr(predicate::str::is_empty());
+
+    let masked = fs::read_to_string(secret_path).unwrap();
+    assert!(masked.contains("<REDACTED>"));
+    assert!(!masked.contains("AKIAIOSFODNN7EXAMPLE"));
+}

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -56,7 +56,7 @@ PR分割:
 - [x] Finding iteration state machine（renderer 未接続）
 - [x] terminal rendering（safe masked context）
 - [x] diff preview（safe redacted preview）
-- [ ] atomic write
+- [x] atomic write
 - [x] tests with scripted stdin
 
 ## Phase 4: LSP

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2540,7 +2540,7 @@ PR分割:
 - [x] Finding iteration state machine（renderer 未接続）
 - [x] terminal rendering（safe masked context）
 - [x] diff preview（safe redacted preview）
-- [ ] atomic write
+- [x] atomic write
 - [x] tests with scripted stdin
 
 ## Phase 4: LSP

--- a/docs/pr/PR-127-interactive-atomic-write.md
+++ b/docs/pr/PR-127-interactive-atomic-write.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 127
 status: Draft
 created_at: TBD
 branch: feat/interactive-atomic-write
@@ -12,7 +12,7 @@ title: Add interactive atomic write
 ## SOT
 - Title: Add interactive atomic write
 - Status: Draft
-- PR: TBD
+- PR: #127
 
 ## What
 - [x] Connect the interactive `mask` decision to file mutation.
@@ -34,7 +34,7 @@ title: Add interactive atomic write
 - Local scripted interactive integration result: `2 passed; 0 failed`.
 - Unit coverage asserts stale-line refusal, CRLF preservation, and already-masked idempotence.
 - CLI coverage asserts `mask\n` redacts the file and removes the raw AWS key.
-- SOT will be renamed after the PR number is assigned.
+- SOT was renamed after PR #127 was created.
 
 ## Non-goals
 - [x] Do not implement `ignore-line` or `skip-file` mutation.

--- a/docs/pr/PR-TBD-interactive-atomic-write.md
+++ b/docs/pr/PR-TBD-interactive-atomic-write.md
@@ -1,0 +1,46 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/interactive-atomic-write
+commit: fc7024780cc65ee4e7716d98e867c134c1355151
+title: Add interactive atomic write
+---
+
+## SOT
+- Title: Add interactive atomic write
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Connect the interactive `mask` decision to file mutation.
+- [x] Replace only the scanned target line with the existing safe `masked_snippet`.
+- [x] Write masked content through a temp file, flush, preserve permissions, sync, and persist atomically.
+- [x] Refuse to write when the target line changed after scan.
+- [x] Preserve LF/CRLF endings for the replaced line.
+- [x] Add unit and CLI coverage for scripted `mask\n`.
+- [x] Mark the Phase 3 atomic write task complete in roadmap docs.
+
+## Verification
+- [x] `cargo fmt --all --check`
+- [x] `cargo test -p veil-cli interactive_scan -- --nocapture`
+- [x] `cargo test -p veil-cli scan_interactive -- --nocapture`
+- [x] `git diff --check`
+
+## Evidence
+- Local interactive unit test result: `15 passed; 0 failed`.
+- Local scripted interactive integration result: `2 passed; 0 failed`.
+- Unit coverage asserts stale-line refusal, CRLF preservation, and already-masked idempotence.
+- CLI coverage asserts `mask\n` redacts the file and removes the raw AWS key.
+- SOT will be renamed after the PR number is assigned.
+
+## Non-goals
+- [x] Do not implement `ignore-line` or `skip-file` mutation.
+- [x] Do not change non-interactive `veil scan` behavior.
+- [x] Do not implement multi-finding batching or file-level grouping.
+- [x] Do not change the masking algorithm or placeholder policy.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
### SOT
- docs/pr/PR-127-interactive-atomic-write.md

### What
- Connect interactive `mask` decisions to file mutation.
- Replace only the scanned target line with the existing safe `masked_snippet`.
- Write through a temp file with flush, permission preservation, sync, and atomic persist.
- Refuse stale writes when the target line changed after scan.
- Mark the Phase 3 atomic write task complete.

### Verification
- `cargo fmt --all --check`
- `cargo test -p veil-cli interactive_scan -- --nocapture`
- `cargo test -p veil-cli scan_interactive -- --nocapture`
- `git diff --check`
