### PR TITLE
Add LSP tower server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,7 +281,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -752,6 +763,19 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1341,6 +1365,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2065,6 +2095,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "lzma-rust2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2545,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2946,7 +3009,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
- "tower",
+ "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
  "url",
@@ -3256,6 +3319,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3953,6 +4027,20 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -4022,7 +4110,7 @@ dependencies = [
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -4032,6 +4120,40 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tower-service"
@@ -4463,6 +4585,8 @@ dependencies = [
 name = "veil-lsp"
 version = "0.17.0"
 dependencies = [
+ "tokio",
+ "tower-lsp",
  "veil-config",
  "veil-core",
 ]

--- a/crates/veil-lsp/Cargo.toml
+++ b/crates/veil-lsp/Cargo.toml
@@ -11,3 +11,5 @@ path = "src/main.rs"
 [dependencies]
 veil-core = { workspace = true }
 veil-config = { workspace = true }
+tokio = { version = "1.0", features = ["full"] }
+tower-lsp = "0.20"

--- a/crates/veil-lsp/src/main.rs
+++ b/crates/veil-lsp/src/main.rs
@@ -1,9 +1,4 @@
-use std::process::ExitCode;
-
-fn main() -> ExitCode {
-    eprintln!(
-        "{} scaffold is present; tower-lsp integration is not implemented yet.",
-        veil_lsp::server::SERVER_NAME
-    );
-    ExitCode::from(2)
+#[tokio::main]
+async fn main() {
+    veil_lsp::server::run_stdio().await;
 }

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -1,11 +1,83 @@
 pub const SERVER_NAME: &str = "veil-lsp";
 
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::{
+    InitializeParams, InitializeResult, InitializedParams, MessageType, ServerCapabilities,
+    ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind,
+};
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+
+pub struct Backend {
+    client: Client,
+}
+
+impl Backend {
+    fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            capabilities: server_capabilities(),
+            server_info: Some(ServerInfo {
+                name: SERVER_NAME.to_string(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            }),
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "veil-lsp initialized")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub async fn run_stdio() {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    let (service, socket) = LspService::new(Backend::new);
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}
+
+pub fn server_capabilities() -> ServerCapabilities {
+    ServerCapabilities {
+        text_document_sync: Some(TextDocumentSyncCapability::Kind(
+            TextDocumentSyncKind::INCREMENTAL,
+        )),
+        ..ServerCapabilities::default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tower_lsp::lsp_types::TextDocumentSyncCapability;
 
     #[test]
     fn server_name_matches_binary_name() {
         assert_eq!(SERVER_NAME, "veil-lsp");
+    }
+
+    #[test]
+    fn capabilities_advertise_incremental_text_sync() {
+        let capabilities = server_capabilities();
+
+        assert_eq!(
+            capabilities.text_document_sync,
+            Some(TextDocumentSyncCapability::Kind(
+                TextDocumentSyncKind::INCREMENTAL
+            ))
+        );
+        assert!(capabilities.diagnostic_provider.is_none());
+        assert!(capabilities.code_action_provider.is_none());
     }
 }

--- a/docs/design/enterprise_jp_pii/06_lsp_design.md
+++ b/docs/design/enterprise_jp_pii/06_lsp_design.md
@@ -156,7 +156,7 @@ vim.lsp.start({
 ## 6.11 実装タスク
 
 - [x] `crates/veil-lsp` workspace追加。
-- [ ] `tower-lsp` server実装。
+- [x] `tower-lsp` server実装。
 - [ ] `scan_content` をLSPから呼び出す。
 - [ ] UTF-8 byte offset → UTF-16 LSP range変換を実装。
 - [ ] `codeAction` for mask/ignore。

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -62,7 +62,7 @@ PR分割:
 ## Phase 4: LSP
 
 - [x] `crates/veil-lsp` 作成
-- [ ] tower-lsp integration
+- [x] tower-lsp integration
 - [ ] diagnostics mapping
 - [ ] code actions
 - [ ] Neovim doc

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -1595,7 +1595,7 @@ vim.lsp.start({
 ## 6.11 実装タスク
 
 - [x] `crates/veil-lsp` workspace追加。
-- [ ] `tower-lsp` server実装。
+- [x] `tower-lsp` server実装。
 - [ ] `scan_content` をLSPから呼び出す。
 - [ ] UTF-8 byte offset → UTF-16 LSP range変換を実装。
 - [ ] `codeAction` for mask/ignore。
@@ -2546,7 +2546,7 @@ PR分割:
 ## Phase 4: LSP
 
 - [x] `crates/veil-lsp` 作成
-- [ ] tower-lsp integration
+- [x] tower-lsp integration
 - [ ] diagnostics mapping
 - [ ] code actions
 - [ ] Neovim doc

--- a/docs/pr/PR-129-lsp-tower-server.md
+++ b/docs/pr/PR-129-lsp-tower-server.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 129
 status: Draft
 created_at: TBD
 branch: feat/lsp-tower-server
@@ -12,7 +12,7 @@ title: Add LSP tower server
 ## SOT
 - Title: Add LSP tower server
 - Status: Draft
-- PR: TBD
+- PR: #129
 
 ## What
 - [x] Add `tokio` and `tower-lsp` dependencies to `veil-lsp`.
@@ -32,7 +32,7 @@ title: Add LSP tower server
 - `cargo check -p veil-lsp --all-targets` completed successfully.
 - Unit coverage asserts incremental text sync is advertised and diagnostics/code actions remain unset.
 - Cargo.lock records the `tower-lsp` dependency set.
-- SOT will be renamed after the PR number is assigned.
+- SOT was renamed after PR #129 was created.
 
 ## Non-goals
 - [x] Do not map findings to diagnostics.

--- a/docs/pr/PR-TBD-lsp-tower-server.md
+++ b/docs/pr/PR-TBD-lsp-tower-server.md
@@ -1,0 +1,44 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/lsp-tower-server
+commit: 0fb837ac3962c5fdd1d9f886cb4e1d35235e25c4
+title: Add LSP tower server
+---
+
+## SOT
+- Title: Add LSP tower server
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add `tokio` and `tower-lsp` dependencies to `veil-lsp`.
+- [x] Replace the scaffold exit path with a stdio `tower-lsp` server entrypoint.
+- [x] Implement minimal `LanguageServer` initialize/initialized/shutdown handling.
+- [x] Advertise incremental text document sync and no diagnostics/code actions yet.
+- [x] Mark only the Phase 4 tower-lsp integration task complete in roadmap docs.
+
+## Verification
+- [x] `cargo fmt --all --check`
+- [x] `cargo check -p veil-lsp --all-targets`
+- [x] `cargo test -p veil-lsp -- --nocapture`
+- [x] `git diff --check`
+
+## Evidence
+- Local `veil-lsp` unit test result: `2 passed; 0 failed`.
+- `cargo check -p veil-lsp --all-targets` completed successfully.
+- Unit coverage asserts incremental text sync is advertised and diagnostics/code actions remain unset.
+- Cargo.lock records the `tower-lsp` dependency set.
+- SOT will be renamed after the PR number is assigned.
+
+## Non-goals
+- [x] Do not map findings to diagnostics.
+- [x] Do not implement document storage or debounce.
+- [x] Do not implement code actions.
+- [x] Do not wire `veil lsp` into `veil-cli`.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
### SOT
- docs/pr/PR-129-lsp-tower-server.md

### What
- Add `tokio` and `tower-lsp` dependencies to `veil-lsp`.
- Replace the scaffold exit path with a stdio `tower-lsp` server entrypoint.
- Implement minimal initialize/initialized/shutdown handling.
- Advertise incremental text sync while leaving diagnostics/code actions unset.

### Verification
- `cargo fmt --all --check`
- `cargo check -p veil-lsp --all-targets`
- `cargo test -p veil-lsp -- --nocapture`
- `git diff --check`
