### PR TITLE
Add LSP diagnostics mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4585,6 +4585,7 @@ dependencies = [
 name = "veil-lsp"
 version = "0.17.0"
 dependencies = [
+ "serde_json",
  "tokio",
  "tower-lsp",
  "veil-config",

--- a/crates/veil-lsp/Cargo.toml
+++ b/crates/veil-lsp/Cargo.toml
@@ -11,5 +11,6 @@ path = "src/main.rs"
 [dependencies]
 veil-core = { workspace = true }
 veil-config = { workspace = true }
+serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 tower-lsp = "0.20"

--- a/crates/veil-lsp/src/diagnostics.rs
+++ b/crates/veil-lsp/src/diagnostics.rs
@@ -1,1 +1,176 @@
+use serde_json::json;
+use tower_lsp::lsp_types::{
+    Diagnostic, DiagnosticSeverity, NumberOrString, Position as LspPosition, Range as LspRange,
+};
+use veil_core::model::{Finding, Range, Severity};
 
+pub fn findings_to_diagnostics(findings: &[Finding]) -> Vec<Diagnostic> {
+    findings.iter().map(finding_to_diagnostic).collect()
+}
+
+pub fn finding_to_diagnostic(finding: &Finding) -> Diagnostic {
+    Diagnostic {
+        range: range_to_lsp(finding.utf16_range),
+        severity: Some(severity_to_lsp(&finding.severity)),
+        code: Some(NumberOrString::String(finding.rule_id.clone())),
+        code_description: None,
+        source: Some("veil".to_string()),
+        message: format!(
+            "Sensitive data detected by {} (grade {}, score {})",
+            finding.rule_id, finding.grade, finding.score
+        ),
+        related_information: None,
+        tags: None,
+        data: Some(json!({
+            "ruleId": finding.rule_id,
+            "score": finding.score,
+            "grade": finding.grade.to_string(),
+            "maskedSnippet": finding.masked_snippet,
+            "actions": ["mask", "ignore"],
+        })),
+    }
+}
+
+fn severity_to_lsp(severity: &Severity) -> DiagnosticSeverity {
+    match severity {
+        Severity::Critical | Severity::High => DiagnosticSeverity::ERROR,
+        Severity::Medium => DiagnosticSeverity::WARNING,
+        Severity::Low => DiagnosticSeverity::INFORMATION,
+    }
+}
+
+fn range_to_lsp(range: Range) -> LspRange {
+    LspRange {
+        start: position_to_lsp(range.start),
+        end: position_to_lsp(range.end),
+    }
+}
+
+fn position_to_lsp(position: veil_core::model::Position) -> LspPosition {
+    LspPosition {
+        line: position.line,
+        character: position.character,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tower_lsp::lsp_types::{Position, Range as LspRange};
+    use veil_core::model::{FindingSpan, Position as CorePosition};
+    use veil_core::rules::grade::Grade;
+
+    fn finding_with(severity: Severity) -> Finding {
+        Finding {
+            path: PathBuf::from("fixture.txt"),
+            line_number: 3,
+            line_content: "token = raw-secret-value".to_string(),
+            rule_id: "secret.test".to_string(),
+            matched_content: "raw-secret-value".to_string(),
+            masked_snippet: "token = <REDACTED>".to_string(),
+            severity,
+            score: 92,
+            grade: Grade::Critical,
+            span: FindingSpan {
+                byte_start: 8,
+                byte_end: 24,
+            },
+            utf16_range: Range {
+                start: CorePosition {
+                    line: 2,
+                    character: 8,
+                },
+                end: CorePosition {
+                    line: 2,
+                    character: 24,
+                },
+            },
+            context_before: Vec::new(),
+            context_after: Vec::new(),
+            commit_sha: None,
+            author: None,
+            date: None,
+        }
+    }
+
+    #[test]
+    fn diagnostic_range_uses_utf16_range() {
+        let finding = finding_with(Severity::High);
+        let diagnostic = finding_to_diagnostic(&finding);
+
+        assert_eq!(
+            diagnostic.range,
+            LspRange {
+                start: Position {
+                    line: 2,
+                    character: 8
+                },
+                end: Position {
+                    line: 2,
+                    character: 24
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn severity_matches_lsp_contract() {
+        assert_eq!(
+            severity_to_lsp(&Severity::Critical),
+            DiagnosticSeverity::ERROR
+        );
+        assert_eq!(severity_to_lsp(&Severity::High), DiagnosticSeverity::ERROR);
+        assert_eq!(
+            severity_to_lsp(&Severity::Medium),
+            DiagnosticSeverity::WARNING
+        );
+        assert_eq!(
+            severity_to_lsp(&Severity::Low),
+            DiagnosticSeverity::INFORMATION
+        );
+    }
+
+    #[test]
+    fn diagnostic_data_contains_safe_fields_only() {
+        let finding = finding_with(Severity::Critical);
+        let diagnostic = finding_to_diagnostic(&finding);
+        let data = diagnostic.data.expect("diagnostic data");
+        let data_text = data.to_string();
+
+        assert_eq!(
+            data.get("ruleId").and_then(|value| value.as_str()),
+            Some("secret.test")
+        );
+        assert_eq!(
+            data.get("maskedSnippet").and_then(|value| value.as_str()),
+            Some("token = <REDACTED>")
+        );
+        assert_eq!(data.get("score").and_then(|value| value.as_u64()), Some(92));
+        assert_eq!(
+            data.get("grade").and_then(|value| value.as_str()),
+            Some("CRITICAL")
+        );
+        assert_eq!(
+            data.get("actions")
+                .and_then(|value| value.as_array())
+                .map(Vec::len),
+            Some(2)
+        );
+        assert!(!data_text.contains("raw-secret-value"));
+        assert!(!data_text.contains("token = raw-secret-value"));
+    }
+
+    #[test]
+    fn diagnostics_preserve_finding_order() {
+        let findings = vec![finding_with(Severity::Low), finding_with(Severity::High)];
+        let diagnostics = findings_to_diagnostics(&findings);
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics[0].severity,
+            Some(DiagnosticSeverity::INFORMATION)
+        );
+        assert_eq!(diagnostics[1].severity, Some(DiagnosticSeverity::ERROR));
+    }
+}

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -63,7 +63,7 @@ PR分割:
 
 - [x] `crates/veil-lsp` 作成
 - [x] tower-lsp integration
-- [ ] diagnostics mapping
+- [x] diagnostics mapping
 - [ ] code actions
 - [ ] Neovim doc
 

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2547,7 +2547,7 @@ PR分割:
 
 - [x] `crates/veil-lsp` 作成
 - [x] tower-lsp integration
-- [ ] diagnostics mapping
+- [x] diagnostics mapping
 - [ ] code actions
 - [ ] Neovim doc
 

--- a/docs/pr/PR-130-lsp-diagnostics-mapping.md
+++ b/docs/pr/PR-130-lsp-diagnostics-mapping.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 130
 status: Draft
 created_at: TBD
 branch: feat/lsp-diagnostics-mapping
@@ -12,7 +12,7 @@ title: Add LSP diagnostics mapping
 ## SOT
 - Title: Add LSP diagnostics mapping
 - Status: Draft
-- PR: TBD
+- PR: #130
 
 ## What
 - [x] Add pure `Finding` to LSP `Diagnostic` mapping in `veil-lsp`.

--- a/docs/pr/PR-TBD-lsp-diagnostics-mapping.md
+++ b/docs/pr/PR-TBD-lsp-diagnostics-mapping.md
@@ -1,0 +1,43 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/lsp-diagnostics-mapping
+commit: 95493211e2179a0f17e3fc9a77d153d776a38fa6
+title: Add LSP diagnostics mapping
+---
+
+## SOT
+- Title: Add LSP diagnostics mapping
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add pure `Finding` to LSP `Diagnostic` mapping in `veil-lsp`.
+- [x] Use `Finding.utf16_range` as the only diagnostic range source.
+- [x] Map Veil severities to LSP severity levels.
+- [x] Populate diagnostic `data` with `ruleId`, `score`, `grade`, `maskedSnippet`, and `actions` only.
+- [x] Mark only the Phase 4 diagnostics mapping task complete in roadmap docs.
+
+## Verification
+- [x] `cargo fmt --all --check`
+- [x] `cargo check -p veil-lsp --all-targets`
+- [x] `cargo test -p veil-lsp diagnostics -- --nocapture`
+- [x] `git diff --check`
+
+## Evidence
+- Local `veil-lsp` diagnostics unit tests passed: `4 passed; 0 failed`.
+- `cargo check -p veil-lsp --all-targets` completed successfully.
+- Unit coverage asserts UTF-16 range use, severity mapping, safe diagnostic data, and finding order preservation.
+- Diagnostic data tests assert raw `line_content` and `matched_content` do not leak.
+
+## Non-goals
+- [x] Do not call `scan_content` from LSP.
+- [x] Do not advertise diagnostics capability from the server yet.
+- [x] Do not implement document storage, debounce, or publication.
+- [x] Do not implement code actions.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- add pure Finding to LSP Diagnostic mapping in veil-lsp
- use Finding.utf16_range as the diagnostic range source
- keep diagnostic data limited to ruleId, score, grade, maskedSnippet, and actions
- mark the Phase 4 diagnostics mapping roadmap item complete

## Verification
- cargo fmt --all --check
- cargo check -p veil-lsp --all-targets
- cargo test -p veil-lsp diagnostics -- --nocapture
- git diff --check

### SOT
- docs/pr/PR-130-lsp-diagnostics-mapping.md