### PR TITLE
Show evidence export after scans

### DIFF
--- a/crates/veil-pro/frontend/src/lib/ScanView.svelte
+++ b/crates/veil-pro/frontend/src/lib/ScanView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FolderSearch, AlertTriangle, ShieldCheck, Play, Loader2, RotateCcw } from 'lucide-svelte';
+  import { FolderSearch, AlertTriangle, ShieldCheck, Play, Loader2, RotateCcw, Download } from 'lucide-svelte';
   import type { ErrorEnvelope, PresetName, SafeFindingApiV1, ScanRequest, ScanResponse, SeverityName } from './api-contract';
   
   // Strict State Machine for UI prediction and tracking (no implicit states)
@@ -264,6 +264,13 @@
   {#if currentState === 'SuccessNoFindings' || currentState === 'Violation' || currentState === 'Incomplete'}
     {#if scanStats}
     <div class="results-area state-anim">
+      <div class="results-toolbar">
+        <h4>Scan Results</h4>
+        <button class="export-link btn btn-secondary btn-sm" onclick={() => downloadEvidence(scanStats!.runId)} type="button">
+          <Download size={14} /> Export Evidence Pack
+        </button>
+      </div>
+
       <div class="stats-cards">
         <div class="stat-card glass-panel">
           <span class="stat-value">{safeInt(scanStats.scanned)}</span>
@@ -295,9 +302,6 @@
         <div class="findings-table glass-panel">
           <div class="table-header">
             <h4>Detected Violations</h4>
-            <button class="export-link btn btn-secondary btn-sm" onclick={() => downloadEvidence(scanStats!.runId)} type="button">
-              Export Evidence Pack
-            </button>
           </div>
           
           <div class="table-wrapper">
@@ -539,6 +543,34 @@
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 16px;
     margin-bottom: 24px;
+  }
+
+  .results-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 16px;
+  }
+
+  .results-toolbar h4 {
+    margin: 0;
+    font-size: 18px;
+  }
+
+  .export-link {
+    flex: 0 0 auto;
+  }
+
+  @media (max-width: 720px) {
+    .results-toolbar {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .export-link {
+      width: 100%;
+    }
   }
 
   .stat-card {

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -72,7 +72,7 @@ PR分割:
 - [ ] API schema alignment
 - [ ] Svelte state machine
 - [ ] Policy explain
-- [ ] Evidence ZIP UX
+- [x] Evidence ZIP UX
 - [ ] PDF export path検討
 
 ## Phase 6: PDF Report

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2556,7 +2556,7 @@ PR分割:
 - [ ] API schema alignment
 - [ ] Svelte state machine
 - [ ] Policy explain
-- [ ] Evidence ZIP UX
+- [x] Evidence ZIP UX
 - [ ] PDF export path検討
 
 ## Phase 6: PDF Report

--- a/docs/pr/PR-131-ui-evidence-export-availability.md
+++ b/docs/pr/PR-131-ui-evidence-export-availability.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 131
 status: Draft
 created_at: TBD
 branch: feat/ui-evidence-export-availability
@@ -12,7 +12,7 @@ title: Show evidence export after scans
 ## SOT
 - Title: Show evidence export after scans
 - Status: Draft
-- PR: TBD
+- PR: #131
 
 ## What
 - [x] Move the Evidence ZIP export action to the shared scan results toolbar.

--- a/docs/pr/PR-TBD-ui-evidence-export-availability.md
+++ b/docs/pr/PR-TBD-ui-evidence-export-availability.md
@@ -1,0 +1,41 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/ui-evidence-export-availability
+commit: 95493211e2179a0f17e3fc9a77d153d776a38fa6
+title: Show evidence export after scans
+---
+
+## SOT
+- Title: Show evidence export after scans
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Move the Evidence ZIP export action to the shared scan results toolbar.
+- [x] Keep the export action visible for zero-finding, violation, and incomplete scan results.
+- [x] Add a download icon to the export button.
+- [x] Mark the Phase 5 Evidence ZIP UX roadmap item complete.
+
+## Verification
+- [x] `npm ci`
+- [x] `npm run check`
+- [x] `npm run build`
+- [x] `git diff --check`
+
+## Evidence
+- `svelte-check` completed with `0 errors and 0 warnings`.
+- Vite production build completed successfully.
+- The export button now depends on `scanStats` instead of `sortedFindings.length > 0`.
+
+## Non-goals
+- [x] Do not change Evidence ZIP generation or backend cache behavior.
+- [x] Do not add filtering, search, or policy explain UI.
+- [x] Do not change Local API schemas.
+- [x] Do not address existing npm audit findings.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- move the Evidence ZIP export action to the shared scan results toolbar
- keep evidence export available for zero-finding, violation, and incomplete scan results
- mark the Phase 5 Evidence ZIP UX roadmap item complete

## Verification
- npm ci
- npm run check
- npm run build
- git diff --check

### SOT
- docs/pr/PR-131-ui-evidence-export-availability.md