### PR TITLE
Show policy summary in UI

### DIFF
--- a/crates/veil-pro/frontend/src/lib/Dashboard.svelte
+++ b/crates/veil-pro/frontend/src/lib/Dashboard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Shield, LayoutDashboard, ScanSearch, FileCheck2, Settings, UserCircle, LogOut } from 'lucide-svelte';
   import ScanView from './ScanView.svelte';
+  import PolicyView from './PolicyView.svelte';
 
   type DashboardProps = {
     authType?: string | null;
@@ -81,11 +82,7 @@
       {#if currentView === 'scan'}
         <ScanView />
       {:else if currentView === 'policy'}
-        <div class="glass-panel overview-hero state-anim">
-           <h3>Governance Policy</h3>
-           <p>Active policy applies to all scans in this session.</p>
-           <!-- Future PolicyPanel integration goes here -->
-        </div>
+        <PolicyView />
       {:else}
          <div class="glass-panel overview-hero state-anim">
            <h3>Configuration</h3>

--- a/crates/veil-pro/frontend/src/lib/PolicyView.svelte
+++ b/crates/veil-pro/frontend/src/lib/PolicyView.svelte
@@ -1,0 +1,349 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { AlertTriangle, CheckCircle2, FileCheck2, RefreshCcw } from 'lucide-svelte';
+  import type { ConfigLayerName, ErrorEnvelope, PolicyResponse } from './api-contract';
+
+  let policy = $state<PolicyResponse | null>(null);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+
+  const layerLabels: Record<ConfigLayerName, string> = {
+    builtin: 'Builtin',
+    preset: 'Preset',
+    org: 'Org',
+    repo: 'Repo',
+    cli: 'CLI'
+  };
+
+  onMount(() => {
+    loadPolicy();
+  });
+
+  function authHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {};
+    const token = sessionStorage.getItem('veil_token');
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+    return headers;
+  }
+
+  async function readErrorMessage(res: Response, fallback: string): Promise<string> {
+    const err = await res.json().catch(() => null) as Partial<ErrorEnvelope> & { error?: unknown; message?: unknown } | null;
+    if (err?.error && typeof err.error === 'object' && 'message' in err.error) {
+      const message = err.error.message;
+      if (typeof message === 'string') {
+        return message;
+      }
+    }
+    if (typeof err?.message === 'string') {
+      return err.message;
+    }
+    return fallback;
+  }
+
+  async function loadPolicy() {
+    loading = true;
+    errorMsg = null;
+
+    try {
+      const res = await fetch('/api/policy', { headers: authHeaders() });
+      if (res.status === 401) {
+        errorMsg = 'Session expired. Please login again.';
+        policy = null;
+        return;
+      }
+      if (!res.ok) {
+        errorMsg = await readErrorMessage(res, `Failed to load policy (HTTP ${res.status}).`);
+        policy = null;
+        return;
+      }
+      policy = await res.json() as PolicyResponse;
+    } catch (err: unknown) {
+      errorMsg = err instanceof Error ? err.message : 'Network error loading policy.';
+      policy = null;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function layerLabel(layer: ConfigLayerName): string {
+    return layerLabels[layer];
+  }
+</script>
+
+{#if loading}
+  <div class="glass-panel policy-state state-anim">
+    <span class="spin">
+      <RefreshCcw size={18} />
+    </span>
+    <span>Loading policy...</span>
+  </div>
+{:else if errorMsg}
+  <div class="glass-panel policy-state error state-anim">
+    <AlertTriangle size={18} />
+    <span>{errorMsg}</span>
+    <button class="btn btn-sm btn-secondary" onclick={loadPolicy} type="button">
+      <RefreshCcw size={14} /> Retry
+    </button>
+  </div>
+{:else if policy}
+  <div class="policy-container state-anim">
+    <div class="policy-summary">
+      <div class="metric glass-panel">
+        <span class="metric-value">{policy.effectiveRulesCount}</span>
+        <span class="metric-label">Rules</span>
+      </div>
+      <div class="metric glass-panel">
+        <span class="metric-value text-value">{policy.preset || 'Default'}</span>
+        <span class="metric-label">Preset</span>
+      </div>
+      <div class="metric glass-panel" class:active={policy.hasOrgConfig}>
+        <span class="metric-value text-value">{policy.hasOrgConfig ? 'Loaded' : 'None'}</span>
+        <span class="metric-label">Org Config</span>
+      </div>
+      <div class="metric glass-panel">
+        <span class="metric-value text-value">{policy.repoConfigPath ? 'Loaded' : 'None'}</span>
+        <span class="metric-label">Repo Config</span>
+      </div>
+    </div>
+
+    <section class="policy-section glass-panel">
+      <div class="section-heading">
+        <FileCheck2 size={20} color="var(--accent)" />
+        <h3>Config Layers</h3>
+      </div>
+      <div class="layer-list">
+        {#each policy.layers as layer}
+          <div class="layer-row" class:loaded={layer.loaded}>
+            <div class="layer-status">
+              {#if layer.loaded}
+                <CheckCircle2 size={16} />
+              {:else}
+                <span class="empty-status"></span>
+              {/if}
+            </div>
+            <div class="layer-main">
+              <strong>{layerLabel(layer.name)}</strong>
+              <span>{layer.path || 'Not set'}</span>
+            </div>
+            <span class="warning-count" class:warn={layer.warnings.length > 0}>
+              {layer.warnings.length} warnings
+            </span>
+          </div>
+        {/each}
+      </div>
+    </section>
+
+    <section class="policy-section glass-panel">
+      <div class="section-heading">
+        <AlertTriangle size={20} color={policy.conflicts.length > 0 ? 'var(--warning)' : 'var(--text-secondary)'} />
+        <h3>Config Conflicts</h3>
+      </div>
+      {#if policy.conflicts.length > 0}
+        <div class="conflict-list">
+          {#each policy.conflicts as conflict}
+            <div class="conflict-row">
+              <strong>{conflict.key}</strong>
+              <span>{layerLabel(conflict.winner)} wins over {conflict.shadowed.map(layerLabel).join(', ')}</span>
+              <p>{conflict.explanation}</p>
+            </div>
+          {/each}
+        </div>
+      {:else}
+        <p class="empty-copy">No config conflicts.</p>
+      {/if}
+    </section>
+  </div>
+{/if}
+
+<style>
+  .state-anim {
+    animation: fadeIn 0.15s ease-out forwards;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .state-anim {
+      animation: none !important;
+    }
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .policy-container {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    max-width: 1000px;
+    margin: 0 auto;
+  }
+
+  .policy-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+  }
+
+  .metric {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 132px;
+    text-align: center;
+  }
+
+  .metric.active {
+    border-color: rgba(52, 199, 89, 0.24);
+  }
+
+  .metric-value {
+    font-size: 40px;
+    font-weight: 700;
+    line-height: 1;
+    margin-bottom: 8px;
+  }
+
+  .metric-value.text-value {
+    font-size: 22px;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+  }
+
+  .metric-label {
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  .policy-section {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .section-heading {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+  }
+
+  .section-heading h3 {
+    font-size: 18px;
+    margin: 0;
+  }
+
+  .layer-list,
+  .conflict-list {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .layer-row,
+  .conflict-row {
+    border-top: 1px solid var(--glass-border);
+    display: grid;
+    gap: 12px;
+    padding: 14px 0;
+  }
+
+  .layer-row {
+    align-items: center;
+    grid-template-columns: 24px minmax(0, 1fr) auto;
+  }
+
+  .layer-row.loaded .layer-status {
+    color: var(--success);
+  }
+
+  .layer-status {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+  }
+
+  .empty-status {
+    background: var(--glass-border);
+    border-radius: 50%;
+    display: inline-block;
+    height: 8px;
+    width: 8px;
+  }
+
+  .layer-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .layer-main strong,
+  .conflict-row strong {
+    font-size: 14px;
+  }
+
+  .layer-main span,
+  .conflict-row span,
+  .empty-copy {
+    color: var(--text-secondary);
+    font-size: 13px;
+    overflow-wrap: anywhere;
+  }
+
+  .warning-count {
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    padding: 4px 10px;
+    white-space: nowrap;
+  }
+
+  .warning-count.warn {
+    color: var(--warning);
+  }
+
+  .conflict-row {
+    grid-template-columns: minmax(120px, 240px) minmax(0, 1fr);
+  }
+
+  .conflict-row p {
+    grid-column: 1 / -1;
+    margin: 0;
+  }
+
+  .policy-state {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+    margin: 0 auto;
+    max-width: 1000px;
+  }
+
+  .policy-state.error {
+    color: var(--danger);
+  }
+
+  .spin {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+
+  @media (max-width: 720px) {
+    .layer-row,
+    .conflict-row {
+      grid-template-columns: 1fr;
+    }
+
+    .layer-status {
+      display: none;
+    }
+  }
+</style>

--- a/crates/veil-pro/frontend/src/lib/api-contract.ts
+++ b/crates/veil-pro/frontend/src/lib/api-contract.ts
@@ -6,6 +6,7 @@ export type GradeName = 'Low' | 'Medium' | 'High' | 'Critical';
 export type BaselineStatus = 'none' | 'new' | 'suppressed';
 export type PresetName = 'standard-jp' | 'fintech-jp' | 'gov-jp' | 'si-vendor-jp' | 'logs-jp';
 export type ScanMode = 'full' | 'staged' | 'ci';
+export type ConfigLayerName = 'builtin' | 'preset' | 'org' | 'repo' | 'cli';
 export type RunStatus = 'success' | 'violation' | 'incomplete' | 'error';
 export type ErrorCode =
   | 'INVALID_REQUEST'
@@ -74,6 +75,31 @@ export type ScanResponse = {
   builtinSkips: string[];
   findings: SafeFindingApiV1[];
   expiresAtUtc: string;
+};
+
+export type ConfigLayerSummary = {
+  name: ConfigLayerName;
+  path?: string | null;
+  loaded: boolean;
+  warnings: string[];
+};
+
+export type ConfigConflict = {
+  key: string;
+  winner: ConfigLayerName;
+  shadowed: ConfigLayerName[];
+  explanation: string;
+};
+
+export type PolicyResponse = {
+  schemaVersion: LocalApiSchemaVersion;
+  hasOrgConfig: boolean;
+  orgConfigPath?: string | null;
+  repoConfigPath?: string | null;
+  effectiveRulesCount: number;
+  preset?: string | null;
+  layers: ConfigLayerSummary[];
+  conflicts: ConfigConflict[];
 };
 
 export type ErrorEnvelope = {

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -71,7 +71,7 @@ PR分割:
 
 - [ ] API schema alignment
 - [ ] Svelte state machine
-- [ ] Policy explain
+- [x] Policy explain
 - [x] Evidence ZIP UX
 - [ ] PDF export path検討
 

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2555,7 +2555,7 @@ PR分割:
 
 - [ ] API schema alignment
 - [ ] Svelte state machine
-- [ ] Policy explain
+- [x] Policy explain
 - [x] Evidence ZIP UX
 - [ ] PDF export path検討
 

--- a/docs/pr/PR-132-ui-policy-summary.md
+++ b/docs/pr/PR-132-ui-policy-summary.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 132
 status: Draft
 created_at: TBD
 branch: feat/ui-policy-summary
@@ -12,7 +12,7 @@ title: Show policy summary in UI
 ## SOT
 - Title: Show policy summary in UI
 - Status: Draft
-- PR: TBD
+- PR: #132
 
 ## What
 - [x] Add UI contract types for `/api/policy`.

--- a/docs/pr/PR-TBD-ui-policy-summary.md
+++ b/docs/pr/PR-TBD-ui-policy-summary.md
@@ -1,0 +1,41 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/ui-policy-summary
+commit: 313f35d55ea645232c690d1e3828d6962bfa551e
+title: Show policy summary in UI
+---
+
+## SOT
+- Title: Show policy summary in UI
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add UI contract types for `/api/policy`.
+- [x] Add a `PolicyView` that fetches and renders the active policy summary.
+- [x] Replace the governance placeholder with live policy data.
+- [x] Mark the Phase 5 Policy explain roadmap item complete.
+
+## Verification
+- [x] `npm ci`
+- [x] `npm run check`
+- [x] `npm run build`
+- [x] `git diff --check`
+
+## Evidence
+- `svelte-check` completed with `0 errors and 0 warnings`.
+- Vite production build completed successfully.
+- Policy UI reads `/api/policy` and displays effective rules, preset, org/repo config presence, layers, warnings, and conflicts.
+
+## Non-goals
+- [x] Do not change backend policy calculation.
+- [x] Do not add policy editing.
+- [x] Do not change Local API schemas.
+- [x] Do not implement the broader Svelte state machine work.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- add frontend contract types for /api/policy
- replace the Organization Policy placeholder with live policy data
- show effective rules, preset, config layer status, warnings, and conflicts
- mark the Phase 5 Policy explain roadmap item complete

## Verification
- npm ci
- npm run check
- npm run build
- git diff --check

### SOT
- docs/pr/PR-132-ui-policy-summary.md