### PR TITLE
Add UI state machine types

### DIFF
--- a/crates/veil-pro/frontend/src/App.svelte
+++ b/crates/veil-pro/frontend/src/App.svelte
@@ -2,12 +2,9 @@
   import { onMount } from 'svelte';
   import Login from './lib/Login.svelte';
   import Dashboard from './lib/Dashboard.svelte';
+  import type { AuthState } from './lib/ui-state';
 
-  let isAuthenticated = $state(false);
-  let authType = $state<string | null>(null);
-  let userEmail = $state<string | null>(null);
-  let userName = $state<string | null>(null);
-  let initialized = $state(false);
+  let authState = $state<AuthState>({ kind: 'Checking' });
 
   onMount(async () => {
     // 1. Check URL Fragment for CLI token injection
@@ -30,30 +27,38 @@
       const res = await fetch('/api/me', { headers });
       if (res.ok) {
         const data = await res.json();
-        isAuthenticated = true;
-        authType = data.type;
-        userEmail = data.email || null;
-        userName = data.name || null;
+        authState = {
+          kind: 'Authenticated',
+          session: {
+            authType: data.type,
+            userEmail: data.email || null,
+            userName: data.name || null
+          }
+        };
       } else {
         // Clear stale local token if server rejected it
         if (storedToken && res.status === 401) {
           sessionStorage.removeItem('veil_token');
         }
+        authState = { kind: 'Unauthenticated' };
       }
     } catch (e) {
-        console.error("Auth check failed:", e);
+      authState = { kind: 'Unauthenticated' };
     }
-    initialized = true;
   });
 </script>
 
-{#if !initialized}
+{#if authState.kind === 'Checking'}
   <div class="loader-container">
     <div class="spinner"></div>
     <p>Authenticating...</p>
   </div>
-{:else if isAuthenticated}
-  <Dashboard {authType} {userName} {userEmail} />
+{:else if authState.kind === 'Authenticated'}
+  <Dashboard
+    authType={authState.session.authType}
+    userEmail={authState.session.userEmail}
+    userName={authState.session.userName}
+  />
 {:else}
   <Login />
 {/if}

--- a/crates/veil-pro/frontend/src/lib/Dashboard.svelte
+++ b/crates/veil-pro/frontend/src/lib/Dashboard.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Shield, LayoutDashboard, ScanSearch, FileCheck2, Settings, UserCircle, LogOut } from 'lucide-svelte';
+  import { Shield, ScanSearch, FileCheck2, Settings, UserCircle, LogOut } from 'lucide-svelte';
   import ScanView from './ScanView.svelte';
   import PolicyView from './PolicyView.svelte';
+  import type { DashboardView } from './ui-state';
 
   type DashboardProps = {
     authType?: string | null;
@@ -11,8 +12,7 @@
 
   let { authType = null, userName = null, userEmail = null }: DashboardProps = $props();
 
-  // v1.0.0 strict local-first architecture (No SSO, Local Token Auth)
-  let currentView = $state('scan');
+  let currentView = $state<DashboardView>('scan');
   let displayName = $derived(userName || userEmail || 'Local Admin');
   let sessionLabel = $derived(authType === 'sso' ? 'SSO Session' : 'CLI Session');
 </script>

--- a/crates/veil-pro/frontend/src/lib/PolicyView.svelte
+++ b/crates/veil-pro/frontend/src/lib/PolicyView.svelte
@@ -2,10 +2,9 @@
   import { onMount } from 'svelte';
   import { AlertTriangle, CheckCircle2, FileCheck2, RefreshCcw } from 'lucide-svelte';
   import type { ConfigLayerName, ErrorEnvelope, PolicyResponse } from './api-contract';
+  import type { PolicyViewState } from './ui-state';
 
-  let policy = $state<PolicyResponse | null>(null);
-  let loading = $state(true);
-  let errorMsg = $state<string | null>(null);
+  let viewState = $state<PolicyViewState>({ kind: 'Loading' });
 
   const layerLabels: Record<ConfigLayerName, string> = {
     builtin: 'Builtin',
@@ -43,27 +42,33 @@
   }
 
   async function loadPolicy() {
-    loading = true;
-    errorMsg = null;
+    viewState = { kind: 'Loading' };
 
     try {
       const res = await fetch('/api/policy', { headers: authHeaders() });
       if (res.status === 401) {
-        errorMsg = 'Session expired. Please login again.';
-        policy = null;
+        viewState = {
+          kind: 'ErrorAuth',
+          message: 'Session expired. Please login again.'
+        };
         return;
       }
       if (!res.ok) {
-        errorMsg = await readErrorMessage(res, `Failed to load policy (HTTP ${res.status}).`);
-        policy = null;
+        viewState = {
+          kind: 'ErrorUnknown',
+          message: await readErrorMessage(res, `Failed to load policy (HTTP ${res.status}).`)
+        };
         return;
       }
-      policy = await res.json() as PolicyResponse;
+      viewState = {
+        kind: 'Ready',
+        policy: await res.json() as PolicyResponse
+      };
     } catch (err: unknown) {
-      errorMsg = err instanceof Error ? err.message : 'Network error loading policy.';
-      policy = null;
-    } finally {
-      loading = false;
+      viewState = {
+        kind: 'ErrorUnknown',
+        message: err instanceof Error ? err.message : 'Network error loading policy.'
+      };
     }
   }
 
@@ -72,38 +77,38 @@
   }
 </script>
 
-{#if loading}
+{#if viewState.kind === 'Loading'}
   <div class="glass-panel policy-state state-anim">
     <span class="spin">
       <RefreshCcw size={18} />
     </span>
     <span>Loading policy...</span>
   </div>
-{:else if errorMsg}
+{:else if viewState.kind === 'ErrorAuth' || viewState.kind === 'ErrorUnknown'}
   <div class="glass-panel policy-state error state-anim">
     <AlertTriangle size={18} />
-    <span>{errorMsg}</span>
+    <span>{viewState.message}</span>
     <button class="btn btn-sm btn-secondary" onclick={loadPolicy} type="button">
       <RefreshCcw size={14} /> Retry
     </button>
   </div>
-{:else if policy}
+{:else if viewState.kind === 'Ready'}
   <div class="policy-container state-anim">
     <div class="policy-summary">
       <div class="metric glass-panel">
-        <span class="metric-value">{policy.effectiveRulesCount}</span>
+        <span class="metric-value">{viewState.policy.effectiveRulesCount}</span>
         <span class="metric-label">Rules</span>
       </div>
       <div class="metric glass-panel">
-        <span class="metric-value text-value">{policy.preset || 'Default'}</span>
+        <span class="metric-value text-value">{viewState.policy.preset || 'Default'}</span>
         <span class="metric-label">Preset</span>
       </div>
-      <div class="metric glass-panel" class:active={policy.hasOrgConfig}>
-        <span class="metric-value text-value">{policy.hasOrgConfig ? 'Loaded' : 'None'}</span>
+      <div class="metric glass-panel" class:active={viewState.policy.hasOrgConfig}>
+        <span class="metric-value text-value">{viewState.policy.hasOrgConfig ? 'Loaded' : 'None'}</span>
         <span class="metric-label">Org Config</span>
       </div>
       <div class="metric glass-panel">
-        <span class="metric-value text-value">{policy.repoConfigPath ? 'Loaded' : 'None'}</span>
+        <span class="metric-value text-value">{viewState.policy.repoConfigPath ? 'Loaded' : 'None'}</span>
         <span class="metric-label">Repo Config</span>
       </div>
     </div>
@@ -114,7 +119,7 @@
         <h3>Config Layers</h3>
       </div>
       <div class="layer-list">
-        {#each policy.layers as layer}
+        {#each viewState.policy.layers as layer}
           <div class="layer-row" class:loaded={layer.loaded}>
             <div class="layer-status">
               {#if layer.loaded}
@@ -137,12 +142,12 @@
 
     <section class="policy-section glass-panel">
       <div class="section-heading">
-        <AlertTriangle size={20} color={policy.conflicts.length > 0 ? 'var(--warning)' : 'var(--text-secondary)'} />
+        <AlertTriangle size={20} color={viewState.policy.conflicts.length > 0 ? 'var(--warning)' : 'var(--text-secondary)'} />
         <h3>Config Conflicts</h3>
       </div>
-      {#if policy.conflicts.length > 0}
+      {#if viewState.policy.conflicts.length > 0}
         <div class="conflict-list">
-          {#each policy.conflicts as conflict}
+          {#each viewState.policy.conflicts as conflict}
             <div class="conflict-row">
               <strong>{conflict.key}</strong>
               <span>{layerLabel(conflict.winner)} wins over {conflict.shadowed.map(layerLabel).join(', ')}</span>

--- a/crates/veil-pro/frontend/src/lib/ScanView.svelte
+++ b/crates/veil-pro/frontend/src/lib/ScanView.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import { FolderSearch, AlertTriangle, ShieldCheck, Play, Loader2, RotateCcw, Download } from 'lucide-svelte';
   import type { ErrorEnvelope, PresetName, SafeFindingApiV1, ScanRequest, ScanResponse, SeverityName } from './api-contract';
+  import type { ScanPreset, ScanState } from './ui-state';
   
-  // Strict State Machine for UI prediction and tracking (no implicit states)
-  type ScanState = 'Idle' | 'Running' | 'SuccessNoFindings' | 'Violation' | 'Incomplete' | 'ErrorAuth' | 'ErrorConfig' | 'ErrorExpired' | 'ErrorOOM' | 'ErrorUnknown';
-  type ScanPreset = '' | PresetName;
   let currentState = $state<ScanState>('Idle');
   
   let scanPath = $state('');

--- a/crates/veil-pro/frontend/src/lib/ui-state.ts
+++ b/crates/veil-pro/frontend/src/lib/ui-state.ts
@@ -1,0 +1,34 @@
+import type { PolicyResponse, PresetName } from './api-contract';
+
+export type AuthSession = {
+  authType: string | null;
+  userEmail: string | null;
+  userName: string | null;
+};
+
+export type AuthState =
+  | { kind: 'Checking' }
+  | { kind: 'Authenticated'; session: AuthSession }
+  | { kind: 'Unauthenticated' };
+
+export type DashboardView = 'scan' | 'policy' | 'settings';
+
+export type PolicyViewState =
+  | { kind: 'Loading' }
+  | { kind: 'Ready'; policy: PolicyResponse }
+  | { kind: 'ErrorAuth'; message: string }
+  | { kind: 'ErrorUnknown'; message: string };
+
+export type ScanState =
+  | 'Idle'
+  | 'Running'
+  | 'SuccessNoFindings'
+  | 'Violation'
+  | 'Incomplete'
+  | 'ErrorAuth'
+  | 'ErrorConfig'
+  | 'ErrorExpired'
+  | 'ErrorOOM'
+  | 'ErrorUnknown';
+
+export type ScanPreset = '' | PresetName;

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -70,7 +70,7 @@ PR分割:
 ## Phase 5: Local Audit UI completion
 
 - [ ] API schema alignment
-- [ ] Svelte state machine
+- [x] Svelte state machine
 - [x] Policy explain
 - [x] Evidence ZIP UX
 - [ ] PDF export path検討

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2554,7 +2554,7 @@ PR分割:
 ## Phase 5: Local Audit UI completion
 
 - [ ] API schema alignment
-- [ ] Svelte state machine
+- [x] Svelte state machine
 - [x] Policy explain
 - [x] Evidence ZIP UX
 - [ ] PDF export path検討

--- a/docs/pr/PR-133-ui-state-machine.md
+++ b/docs/pr/PR-133-ui-state-machine.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: A
-pr: TBD
+pr: 133
 status: Draft
 created_at: TBD
 branch: feat/ui-state-machine
@@ -12,7 +12,7 @@ title: Add UI state machine types
 ## SOT
 - Title: Add UI state machine types
 - Status: Draft
-- PR: TBD
+- PR: #133
 
 ## What
 - [x] Add shared UI state machine types for auth, dashboard view, policy view, and scan view.

--- a/docs/pr/PR-TBD-ui-state-machine.md
+++ b/docs/pr/PR-TBD-ui-state-machine.md
@@ -1,0 +1,43 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: TBD
+branch: feat/ui-state-machine
+commit: 966c7e5f97b0a9bbfac87fb36bdf59306a056d92
+title: Add UI state machine types
+---
+
+## SOT
+- Title: Add UI state machine types
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add shared UI state machine types for auth, dashboard view, policy view, and scan view.
+- [x] Replace App auth booleans with an explicit `AuthState`.
+- [x] Type Dashboard navigation with `DashboardView`.
+- [x] Replace PolicyView loading/error/data booleans with a `PolicyViewState`.
+- [x] Keep ScanView on the same states while moving the state type to the shared module.
+- [x] Mark the Phase 5 Svelte state machine roadmap item complete.
+
+## Verification
+- [x] `npm ci`
+- [x] `npm run check`
+- [x] `npm run build`
+- [x] `git diff --check`
+
+## Evidence
+- `svelte-check` completed with `0 errors and 0 warnings`.
+- Vite production build completed successfully.
+- Auth, dashboard, policy, and scan view states now use named TypeScript unions.
+
+## Non-goals
+- [x] Do not change backend APIs.
+- [x] Do not redesign scan result rendering.
+- [x] Do not add new UI routes.
+- [x] Do not implement API schema alignment.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- add shared TypeScript state machine types for auth, dashboard, policy, and scan views
- replace App auth booleans with an explicit AuthState
- type Dashboard navigation and PolicyView loading/error/ready states
- mark the Phase 5 Svelte state machine roadmap item complete

## Verification
- npm ci
- npm run check
- npm run build
- git diff --check

### SOT
- docs/pr/PR-133-ui-state-machine.md