### PR TITLE
Publish LSP diagnostics

### DIFF
--- a/crates/veil-lsp/src/document_store.rs
+++ b/crates/veil-lsp/src/document_store.rs
@@ -1,1 +1,237 @@
+use std::collections::HashMap;
+use std::fmt;
 
+use tower_lsp::lsp_types::{
+    Position as LspPosition, Range as LspRange, TextDocumentContentChangeEvent, Url,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentState {
+    pub uri: Url,
+    pub text: String,
+    pub version: i32,
+}
+
+#[derive(Debug, Default)]
+pub struct DocumentStore {
+    documents: HashMap<Url, DocumentState>,
+}
+
+impl DocumentStore {
+    pub fn open(&mut self, uri: Url, text: String, version: i32) -> DocumentState {
+        let document = DocumentState {
+            uri: uri.clone(),
+            text,
+            version,
+        };
+        self.documents.insert(uri, document.clone());
+        document
+    }
+
+    pub fn apply_changes(
+        &mut self,
+        uri: &Url,
+        version: i32,
+        content_changes: Vec<TextDocumentContentChangeEvent>,
+    ) -> Result<Option<DocumentState>, DocumentChangeError> {
+        let Some(document) = self.documents.get_mut(uri) else {
+            return Ok(None);
+        };
+
+        for change in content_changes {
+            apply_content_change(&mut document.text, change)?;
+        }
+        document.version = version;
+
+        Ok(Some(document.clone()))
+    }
+
+    pub fn close(&mut self, uri: &Url) {
+        self.documents.remove(uri);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DocumentChangeError {
+    InvalidRange { range: LspRange },
+}
+
+impl fmt::Display for DocumentChangeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DocumentChangeError::InvalidRange { range } => {
+                write!(formatter, "invalid text document change range: {range:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DocumentChangeError {}
+
+fn apply_content_change(
+    text: &mut String,
+    change: TextDocumentContentChangeEvent,
+) -> Result<(), DocumentChangeError> {
+    let Some(range) = change.range else {
+        *text = change.text;
+        return Ok(());
+    };
+
+    let Some(start) = byte_index_for_position(text, range.start) else {
+        return Err(DocumentChangeError::InvalidRange { range });
+    };
+    let Some(end) = byte_index_for_position(text, range.end) else {
+        return Err(DocumentChangeError::InvalidRange { range });
+    };
+    if start > end {
+        return Err(DocumentChangeError::InvalidRange { range });
+    }
+
+    text.replace_range(start..end, &change.text);
+    Ok(())
+}
+
+fn byte_index_for_position(text: &str, position: LspPosition) -> Option<usize> {
+    let (line_start, line_end) = line_byte_bounds(text, position.line)?;
+    let line = &text[line_start..line_end];
+
+    if position.character == 0 {
+        return Some(line_start);
+    }
+
+    let mut utf16_units = 0_u32;
+    for (byte_offset, character) in line.char_indices() {
+        if utf16_units == position.character {
+            return Some(line_start + byte_offset);
+        }
+
+        utf16_units = utf16_units.saturating_add(character.len_utf16() as u32);
+        if utf16_units > position.character {
+            return None;
+        }
+    }
+
+    (utf16_units == position.character).then_some(line_end)
+}
+
+fn line_byte_bounds(text: &str, target_line: u32) -> Option<(usize, usize)> {
+    let mut line = 0_u32;
+    let mut line_start = 0_usize;
+
+    for (byte_offset, character) in text.char_indices() {
+        if character != '\n' {
+            continue;
+        }
+
+        if line == target_line {
+            let line_end = text[line_start..byte_offset]
+                .strip_suffix('\r')
+                .map_or(byte_offset, |line_without_cr| {
+                    line_start + line_without_cr.len()
+                });
+            return Some((line_start, line_end));
+        }
+
+        line = line.saturating_add(1);
+        line_start = byte_offset + character.len_utf8();
+    }
+
+    (line == target_line).then_some((line_start, text.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp::lsp_types::Position;
+
+    fn full_change(text: &str) -> TextDocumentContentChangeEvent {
+        TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: text.to_string(),
+        }
+    }
+
+    fn ranged_change(range: LspRange, text: &str) -> TextDocumentContentChangeEvent {
+        TextDocumentContentChangeEvent {
+            range: Some(range),
+            range_length: None,
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn store_applies_full_document_changes() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+        let mut store = DocumentStore::default();
+        store.open(uri.clone(), "before".to_string(), 1);
+
+        let document = store
+            .apply_changes(&uri, 2, vec![full_change("after")])
+            .expect("change")
+            .expect("document");
+
+        assert_eq!(document.text, "after");
+        assert_eq!(document.version, 2);
+    }
+
+    #[test]
+    fn store_applies_incremental_changes_with_utf16_positions() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+        let mut store = DocumentStore::default();
+        store.open(uri.clone(), "a🙂c".to_string(), 1);
+
+        let document = store
+            .apply_changes(
+                &uri,
+                2,
+                vec![ranged_change(
+                    LspRange {
+                        start: Position {
+                            line: 0,
+                            character: 1,
+                        },
+                        end: Position {
+                            line: 0,
+                            character: 3,
+                        },
+                    },
+                    "b",
+                )],
+            )
+            .expect("change")
+            .expect("document");
+
+        assert_eq!(document.text, "abc");
+    }
+
+    #[test]
+    fn store_rejects_positions_inside_utf16_surrogate_pairs() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+        let mut store = DocumentStore::default();
+        store.open(uri.clone(), "a🙂c".to_string(), 1);
+
+        let result = store.apply_changes(
+            &uri,
+            2,
+            vec![ranged_change(
+                LspRange {
+                    start: Position {
+                        line: 0,
+                        character: 2,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 3,
+                    },
+                },
+                "b",
+            )],
+        );
+
+        assert!(matches!(
+            result,
+            Err(DocumentChangeError::InvalidRange { .. })
+        ));
+    }
+}

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -1,19 +1,51 @@
 pub const SERVER_NAME: &str = "veil-lsp";
 
+use std::path::{Path, PathBuf};
+
+use crate::diagnostics::findings_to_diagnostics;
+use crate::document_store::{DocumentState, DocumentStore};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
+    Diagnostic, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     InitializeParams, InitializeResult, InitializedParams, MessageType, ServerCapabilities,
-    ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind,
+    ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind, Url,
 };
 use tower_lsp::{Client, LanguageServer, LspService, Server};
+use veil_config::Config;
+use veil_core::{scan_content, try_get_all_rules, Rule};
 
 pub struct Backend {
     client: Client,
+    documents: tokio::sync::Mutex<DocumentStore>,
+    config: Config,
+    rules: Vec<Rule>,
 }
 
 impl Backend {
     fn new(client: Client) -> Self {
-        Self { client }
+        let config = Config::default();
+        let rules = try_get_all_rules(&config, Vec::new())
+            .unwrap_or_else(|_| veil_core::get_default_rules());
+
+        Self {
+            client,
+            documents: tokio::sync::Mutex::new(DocumentStore::default()),
+            config,
+            rules,
+        }
+    }
+
+    async fn publish_document_diagnostics(&self, document: DocumentState) {
+        let diagnostics = diagnostics_for_text(
+            &document.text,
+            &path_for_uri(&document.uri),
+            &self.rules,
+            &self.config,
+        );
+
+        self.client
+            .publish_diagnostics(document.uri, diagnostics, Some(document.version))
+            .await;
     }
 }
 
@@ -33,6 +65,53 @@ impl LanguageServer for Backend {
         self.client
             .log_message(MessageType::INFO, "veil-lsp initialized")
             .await;
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let text_document = params.text_document;
+        let document = {
+            let mut documents = self.documents.lock().await;
+            documents.open(text_document.uri, text_document.text, text_document.version)
+        };
+
+        self.publish_document_diagnostics(document).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let (changed_document, change_error) = {
+            let mut documents = self.documents.lock().await;
+            match documents.apply_changes(
+                &params.text_document.uri,
+                params.text_document.version,
+                params.content_changes,
+            ) {
+                Ok(document) => (document, None),
+                Err(error) => (None, Some(error.to_string())),
+            }
+        };
+
+        if let Some(error) = change_error {
+            self.client
+                .log_message(
+                    MessageType::ERROR,
+                    format!("failed to apply text document change: {error}"),
+                )
+                .await;
+        }
+
+        if let Some(document) = changed_document {
+            self.publish_document_diagnostics(document).await;
+        }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let uri = params.text_document.uri;
+        {
+            let mut documents = self.documents.lock().await;
+            documents.close(&uri);
+        }
+
+        self.client.publish_diagnostics(uri, Vec::new(), None).await;
     }
 
     async fn shutdown(&self) -> Result<()> {
@@ -57,10 +136,24 @@ pub fn server_capabilities() -> ServerCapabilities {
     }
 }
 
+pub fn diagnostics_for_text(
+    text: &str,
+    path: &Path,
+    rules: &[Rule],
+    config: &Config,
+) -> Vec<Diagnostic> {
+    findings_to_diagnostics(&scan_content(text, path, rules, config))
+}
+
+fn path_for_uri(uri: &Url) -> PathBuf {
+    uri.to_file_path()
+        .unwrap_or_else(|_| PathBuf::from(uri.path()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tower_lsp::lsp_types::TextDocumentSyncCapability;
+    use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString, TextDocumentSyncCapability};
 
     #[test]
     fn server_name_matches_binary_name() {
@@ -79,5 +172,36 @@ mod tests {
         );
         assert!(capabilities.diagnostic_provider.is_none());
         assert!(capabilities.code_action_provider.is_none());
+    }
+
+    #[test]
+    fn diagnostics_for_text_scans_content_with_default_rules() {
+        let config = Config::default();
+        let rules = try_get_all_rules(&config, Vec::new()).expect("rules");
+        let diagnostics = diagnostics_for_text(
+            "🙂 contact test@example.com\n",
+            Path::new("fixture.txt"),
+            &rules,
+            &config,
+        );
+
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| {
+                matches!(
+                    diagnostic.code.as_ref(),
+                    Some(NumberOrString::String(code)) if code == "pii.net.email"
+                )
+            })
+            .expect("email diagnostic");
+
+        assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+        assert_eq!(diagnostic.range.start.line, 0);
+        assert_eq!(diagnostic.range.start.character, 11);
+
+        let data = diagnostic.data.as_ref().expect("diagnostic data");
+        let data_text = data.to_string();
+        assert!(!data_text.contains("test@example.com"));
+        assert!(!data_text.contains("🙂 contact test@example.com"));
     }
 }

--- a/docs/design/enterprise_jp_pii/06_lsp_design.md
+++ b/docs/design/enterprise_jp_pii/06_lsp_design.md
@@ -157,8 +157,10 @@ vim.lsp.start({
 
 - [x] `crates/veil-lsp` workspace追加。
 - [x] `tower-lsp` server実装。
-- [ ] `scan_content` をLSPから呼び出す。
-- [ ] UTF-8 byte offset → UTF-16 LSP range変換を実装。
+- [x] `scan_content` をLSPから呼び出す。
+- [x] `didOpen` / `didChange` で `publishDiagnostics` を送る。
+- [x] `didClose` でdiagnosticsをclearする。
+- [x] UTF-8 byte offset → UTF-16 LSP range変換はCoreの`Finding.utf16_range`に集約し、LSP Diagnosticでは再計算しない。
 - [ ] `codeAction` for mask/ignore。
 - [ ] 言語別ignore comment registryを実装。
 - [ ] JSON等コメント不可ファイルではinline ignore actionを非表示。

--- a/docs/pr/PR-136-lsp-diagnostics-publish.md
+++ b/docs/pr/PR-136-lsp-diagnostics-publish.md
@@ -1,8 +1,8 @@
 ---
 release: TBD
 epic: A
-pr: TBD
-status: Draft
+pr: 136
+status: Ready
 created_at: 2026-07-08
 branch: feat/lsp-diagnostics-publish
 commit: 1225c4b1b010c65a02aaea35b82e690bbcc9c9e0
@@ -11,8 +11,8 @@ title: Publish LSP diagnostics
 
 ## SOT
 - Title: Publish LSP diagnostics
-- Status: Draft
-- PR: TBD
+- Status: Ready
+- PR: #136
 
 ## What
 - [x] Store opened LSP documents with URI, text, and version.

--- a/docs/pr/PR-TBD-lsp-diagnostics-publish.md
+++ b/docs/pr/PR-TBD-lsp-diagnostics-publish.md
@@ -1,0 +1,48 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: 2026-07-08
+branch: feat/lsp-diagnostics-publish
+commit: 1225c4b1b010c65a02aaea35b82e690bbcc9c9e0
+title: Publish LSP diagnostics
+---
+
+## SOT
+- Title: Publish LSP diagnostics
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Store opened LSP documents with URI, text, and version.
+- [x] Apply full and incremental `didChange` content updates before scanning.
+- [x] Run `scan_content` from the LSP server and convert findings through the existing pure diagnostics mapping.
+- [x] Publish diagnostics on `didOpen` and `didChange`, including the document version.
+- [x] Clear diagnostics on `didClose`.
+- [x] Keep `Finding.utf16_range` as the only diagnostic range source.
+- [x] Keep raw `matched_content` and raw lines out of diagnostic `data`.
+
+## Verification
+- [x] `cargo fmt --all`
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo test -p veil-lsp`
+- [x] `cargo test --workspace --lib --bins`
+- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [x] `git diff --check`
+
+## Evidence
+- Local `veil-lsp` tests passed: `10 passed; 0 failed`.
+- Workspace lib/bin tests passed across `veil-cli`, `veil-config`, `veil-core`, `veil-guardian`, `veil-lsp`, `veil-pro`, and `veil-server`.
+- Workspace clippy passed with `-D warnings`.
+- `document_store` tests cover full document updates, UTF-16 incremental ranges, and invalid surrogate-pair positions.
+- `server` tests cover default-rule scan wiring, UTF-16 diagnostic range preservation, and raw-value exclusion from diagnostic data.
+
+## Non-goals
+- [x] Do not implement code actions.
+- [x] Do not implement debounce or stale revision cancellation yet.
+- [x] Do not add preset/config file loading to LSP startup yet.
+- [x] Do not advertise LSP pull diagnostics; this PR uses `publishDiagnostics` notifications only.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## What
- Wire `didOpen` and `didChange` to scan open document text and publish LSP diagnostics.
- Add a small document store that applies full and incremental LSP text changes with UTF-16 positions.
- Clear diagnostics on `didClose`.
- Keep diagnostic ranges sourced from `Finding.utf16_range` and keep raw findings out of diagnostic `data`.

## SOT
- docs/pr/PR-136-lsp-diagnostics-publish.md

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p veil-lsp`
- `cargo test --workspace --lib --bins`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

## Non-goals
- Code actions
- Debounce/stale scan cancellation
- LSP preset/config loading