### PR TITLE
Debounce LSP diagnostics publishing

### DIFF
--- a/crates/veil-lsp/src/document_store.rs
+++ b/crates/veil-lsp/src/document_store.rs
@@ -10,6 +10,7 @@ pub struct DocumentState {
     pub uri: Url,
     pub text: String,
     pub version: i32,
+    pub scan_revision: u64,
 }
 
 #[derive(Debug, Default)]
@@ -23,6 +24,7 @@ impl DocumentStore {
             uri: uri.clone(),
             text,
             version,
+            scan_revision: 0,
         };
         self.documents.insert(uri, document.clone());
         document
@@ -42,8 +44,19 @@ impl DocumentStore {
             apply_content_change(&mut document.text, change)?;
         }
         document.version = version;
+        document.scan_revision = document.scan_revision.saturating_add(1);
 
         Ok(Some(document.clone()))
+    }
+
+    pub fn get(&self, uri: &Url) -> Option<DocumentState> {
+        self.documents.get(uri).cloned()
+    }
+
+    pub fn has_revision(&self, uri: &Url, scan_revision: u64) -> bool {
+        self.documents
+            .get(uri)
+            .is_some_and(|document| document.scan_revision == scan_revision)
     }
 
     pub fn close(&mut self, uri: &Url) {
@@ -173,6 +186,7 @@ mod tests {
 
         assert_eq!(document.text, "after");
         assert_eq!(document.version, 2);
+        assert_eq!(document.scan_revision, 1);
     }
 
     #[test]
@@ -203,6 +217,7 @@ mod tests {
             .expect("document");
 
         assert_eq!(document.text, "abc");
+        assert_eq!(document.scan_revision, 1);
     }
 
     #[test]
@@ -233,5 +248,38 @@ mod tests {
             result,
             Err(DocumentChangeError::InvalidRange { .. })
         ));
+    }
+
+    #[test]
+    fn open_resets_scan_revision_for_new_document_state() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+        let mut store = DocumentStore::default();
+
+        let original = store.open(uri.clone(), "before".to_string(), 1);
+        assert_eq!(original.scan_revision, 0);
+
+        let updated = store
+            .apply_changes(&uri, 2, vec![full_change("after")])
+            .expect("change")
+            .expect("document");
+        assert_eq!(updated.scan_revision, 1);
+
+        let reopened = store.open(uri, "reopened".to_string(), 1);
+        assert_eq!(reopened.scan_revision, 0);
+    }
+
+    #[test]
+    fn has_revision_tracks_latest_document_generation() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+        let mut store = DocumentStore::default();
+        store.open(uri.clone(), "before".to_string(), 1);
+
+        let updated = store
+            .apply_changes(&uri, 2, vec![full_change("after")])
+            .expect("change")
+            .expect("document");
+
+        assert!(store.has_revision(&uri, updated.scan_revision));
+        assert!(!store.has_revision(&uri, 0));
     }
 }

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -1,6 +1,9 @@
 pub const SERVER_NAME: &str = "veil-lsp";
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
 
 use crate::diagnostics::findings_to_diagnostics;
 use crate::document_store::{DocumentState, DocumentStore};
@@ -14,11 +17,14 @@ use tower_lsp::{Client, LanguageServer, LspService, Server};
 use veil_config::Config;
 use veil_core::{scan_content, try_get_all_rules, Rule};
 
+const CHANGE_SCAN_DEBOUNCE: Duration = Duration::from_millis(200);
+
 pub struct Backend {
     client: Client,
-    documents: tokio::sync::Mutex<DocumentStore>,
-    config: Config,
-    rules: Vec<Rule>,
+    documents: Arc<tokio::sync::Mutex<DocumentStore>>,
+    pending_scans: Arc<tokio::sync::Mutex<PendingScanMap>>,
+    config: Arc<Config>,
+    rules: Arc<Vec<Rule>>,
 }
 
 impl Backend {
@@ -29,23 +35,60 @@ impl Backend {
 
         Self {
             client,
-            documents: tokio::sync::Mutex::new(DocumentStore::default()),
-            config,
-            rules,
+            documents: Arc::new(tokio::sync::Mutex::new(DocumentStore::default())),
+            pending_scans: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            config: Arc::new(config),
+            rules: Arc::new(rules),
         }
     }
 
-    async fn publish_document_diagnostics(&self, document: DocumentState) {
-        let diagnostics = diagnostics_for_text(
-            &document.text,
-            &path_for_uri(&document.uri),
-            &self.rules,
-            &self.config,
-        );
+    async fn schedule_document_diagnostics(&self, document: DocumentState, debounce: Duration) {
+        let uri = document.uri.clone();
+        let task_uri = uri.clone();
+        let scan_revision = document.scan_revision;
+        let client = self.client.clone();
+        let documents = Arc::clone(&self.documents);
+        let pending_scans = Arc::clone(&self.pending_scans);
+        let config = Arc::clone(&self.config);
+        let rules = Arc::clone(&self.rules);
 
-        self.client
-            .publish_diagnostics(document.uri, diagnostics, Some(document.version))
-            .await;
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(debounce).await;
+
+            let Some(document) =
+                current_document_for_revision(&documents, &task_uri, scan_revision).await
+            else {
+                clear_pending_scan_if_current(&pending_scans, &task_uri, scan_revision).await;
+                return;
+            };
+
+            let diagnostics = diagnostics_for_text(
+                &document.text,
+                &path_for_uri(&document.uri),
+                &rules,
+                &config,
+            );
+
+            if current_document_for_revision(&documents, &task_uri, scan_revision)
+                .await
+                .is_some()
+            {
+                client
+                    .publish_diagnostics(task_uri.clone(), diagnostics, Some(document.version))
+                    .await;
+            }
+
+            clear_pending_scan_if_current(&pending_scans, &task_uri, scan_revision).await;
+        });
+
+        replace_pending_scan(&self.pending_scans, uri, scan_revision, handle).await;
+    }
+
+    async fn cancel_pending_scan(&self, uri: &Url) {
+        let mut pending_scans = self.pending_scans.lock().await;
+        if let Some(pending_scan) = pending_scans.remove(uri) {
+            pending_scan.handle.abort();
+        }
     }
 }
 
@@ -74,7 +117,8 @@ impl LanguageServer for Backend {
             documents.open(text_document.uri, text_document.text, text_document.version)
         };
 
-        self.publish_document_diagnostics(document).await;
+        self.schedule_document_diagnostics(document, Duration::ZERO)
+            .await;
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
@@ -100,12 +144,14 @@ impl LanguageServer for Backend {
         }
 
         if let Some(document) = changed_document {
-            self.publish_document_diagnostics(document).await;
+            self.schedule_document_diagnostics(document, CHANGE_SCAN_DEBOUNCE)
+                .await;
         }
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = params.text_document.uri;
+        self.cancel_pending_scan(&uri).await;
         {
             let mut documents = self.documents.lock().await;
             documents.close(&uri);
@@ -148,6 +194,66 @@ pub fn diagnostics_for_text(
 fn path_for_uri(uri: &Url) -> PathBuf {
     uri.to_file_path()
         .unwrap_or_else(|_| PathBuf::from(uri.path()))
+}
+
+type PendingScanMap = HashMap<Url, PendingScan>;
+
+struct PendingScan {
+    scan_revision: u64,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+async fn replace_pending_scan(
+    pending_scans: &tokio::sync::Mutex<PendingScanMap>,
+    uri: Url,
+    scan_revision: u64,
+    handle: tokio::task::JoinHandle<()>,
+) {
+    let mut pending_scans = pending_scans.lock().await;
+    if let Some(previous_scan) = pending_scans.insert(
+        uri,
+        PendingScan {
+            scan_revision,
+            handle,
+        },
+    ) {
+        previous_scan.handle.abort();
+    }
+}
+
+async fn clear_pending_scan_if_current(
+    pending_scans: &tokio::sync::Mutex<PendingScanMap>,
+    uri: &Url,
+    scan_revision: u64,
+) {
+    let mut pending_scans = pending_scans.lock().await;
+    let should_clear = pending_scans
+        .get(uri)
+        .is_some_and(|pending_scan| pending_scan.scan_revision == scan_revision);
+    if should_clear {
+        pending_scans.remove(uri);
+    }
+}
+
+async fn current_document_for_revision(
+    documents: &tokio::sync::Mutex<DocumentStore>,
+    uri: &Url,
+    scan_revision: u64,
+) -> Option<DocumentState> {
+    let documents = documents.lock().await;
+    document_for_revision(&documents, uri, scan_revision)
+}
+
+fn document_for_revision(
+    documents: &DocumentStore,
+    uri: &Url,
+    scan_revision: u64,
+) -> Option<DocumentState> {
+    if documents.has_revision(uri, scan_revision) {
+        return documents.get(uri);
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -203,5 +309,32 @@ mod tests {
         let data_text = data.to_string();
         assert!(!data_text.contains("test@example.com"));
         assert!(!data_text.contains("🙂 contact test@example.com"));
+    }
+
+    #[test]
+    fn change_scan_debounce_matches_design_window() {
+        assert_eq!(CHANGE_SCAN_DEBOUNCE, Duration::from_millis(200));
+    }
+
+    #[test]
+    fn document_for_revision_requires_latest_scan_revision() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+        let mut documents = DocumentStore::default();
+        documents.open(uri.clone(), "before".to_string(), 1);
+        let current = documents
+            .apply_changes(
+                &uri,
+                2,
+                vec![tower_lsp::lsp_types::TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "after".to_string(),
+                }],
+            )
+            .expect("change")
+            .expect("document");
+
+        assert!(document_for_revision(&documents, &uri, current.scan_revision).is_some());
+        assert!(document_for_revision(&documents, &uri, 0).is_none());
     }
 }

--- a/docs/design/enterprise_jp_pii/06_lsp_design.md
+++ b/docs/design/enterprise_jp_pii/06_lsp_design.md
@@ -160,6 +160,7 @@ vim.lsp.start({
 - [x] `scan_content` をLSPから呼び出す。
 - [x] `didOpen` / `didChange` で `publishDiagnostics` を送る。
 - [x] `didClose` でdiagnosticsをclearする。
+- [x] `didChange` のscanを debounce し、同一documentの古い結果をpublishしない。
 - [x] UTF-8 byte offset → UTF-16 LSP range変換はCoreの`Finding.utf16_range`に集約し、LSP Diagnosticでは再計算しない。
 - [ ] `codeAction` for mask/ignore。
 - [ ] 言語別ignore comment registryを実装。

--- a/docs/pr/PR-137-lsp-diagnostics-debounce.md
+++ b/docs/pr/PR-137-lsp-diagnostics-debounce.md
@@ -1,8 +1,8 @@
 ---
 release: TBD
 epic: A
-pr: TBD
-status: Draft
+pr: 137
+status: Ready
 created_at: 2026-07-08
 branch: feat/lsp-diagnostics-debounce
 commit: d7f84f175cd9ed6506d36aa83dcee011a40956bf
@@ -11,8 +11,8 @@ title: Debounce LSP diagnostics publishing
 
 ## SOT
 - Title: Debounce LSP diagnostics publishing
-- Status: Draft
-- PR: TBD
+- Status: Ready
+- PR: #137
 
 ## What
 - [x] Add per-document `scan_revision` tracking to the LSP document store.

--- a/docs/pr/PR-TBD-lsp-diagnostics-debounce.md
+++ b/docs/pr/PR-TBD-lsp-diagnostics-debounce.md
@@ -1,0 +1,47 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: 2026-07-08
+branch: feat/lsp-diagnostics-debounce
+commit: d7f84f175cd9ed6506d36aa83dcee011a40956bf
+title: Debounce LSP diagnostics publishing
+---
+
+## SOT
+- Title: Debounce LSP diagnostics publishing
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add per-document `scan_revision` tracking to the LSP document store.
+- [x] Debounce `didChange` diagnostics publication by 200ms.
+- [x] Abort and replace pending scans when newer edits arrive for the same document.
+- [x] Drop stale or closed-document scan results before publish.
+- [x] Keep `Finding.utf16_range` as the only diagnostic range source.
+- [x] Keep raw `matched_content` and raw lines out of diagnostic `data`.
+
+## Verification
+- [x] `cargo fmt --all`
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo test -p veil-lsp`
+- [x] `cargo test --workspace --lib --bins`
+- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [x] `git diff --check`
+
+## Evidence
+- `veil-lsp` tests passed: `14 passed; 0 failed`.
+- Workspace lib/bin tests passed across `veil-cli`, `veil-config`, `veil-core`, `veil-guardian`, `veil-lsp`, `veil-pro`, and `veil-server`.
+- Workspace clippy passed with `-D warnings`.
+- `document_store` tests now cover revision reset and latest-generation tracking.
+- `server` tests cover debounce interval and latest-revision gating.
+
+## Non-goals
+- [x] Do not implement code actions.
+- [x] Do not add preset/config file loading to LSP startup yet.
+- [x] Do not add size-limit skip diagnostics yet.
+- [x] Do not advertise LSP pull diagnostics; this PR still uses `publishDiagnostics` notifications only.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## What
- Track per-document `scan_revision` values in the LSP document store.
- Debounce `didChange` diagnostics publication by 200ms.
- Abort and replace pending scans when newer edits arrive for the same document.
- Drop stale or closed-document scan results before publish.

## SOT
- docs/pr/PR-137-lsp-diagnostics-debounce.md

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p veil-lsp`
- `cargo test --workspace --lib --bins`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

## Non-goals
- Code actions
- LSP preset/config loading
- Size-limit skip diagnostics