### PR TITLE
Publish LSP max file size skip diagnostic

### DIFF
--- a/crates/veil-lsp/src/diagnostics.rs
+++ b/crates/veil-lsp/src/diagnostics.rs
@@ -3,6 +3,8 @@ use tower_lsp::lsp_types::{
     Diagnostic, DiagnosticSeverity, NumberOrString, Position as LspPosition, Range as LspRange,
 };
 use veil_core::model::{Finding, Range, Severity};
+use veil_core::rules::grade::Grade;
+use veil_core::RULE_ID_MAX_FILE_SIZE;
 
 pub fn findings_to_diagnostics(findings: &[Finding]) -> Vec<Diagnostic> {
     findings.iter().map(finding_to_diagnostic).collect()
@@ -27,6 +29,32 @@ pub fn finding_to_diagnostic(finding: &Finding) -> Diagnostic {
             "grade": finding.grade.to_string(),
             "maskedSnippet": finding.masked_snippet,
             "actions": ["mask", "ignore"],
+        })),
+    }
+}
+
+pub fn max_file_size_diagnostic(file_size_bytes: u64, max_size_bytes: u64) -> Diagnostic {
+    Diagnostic {
+        range: LspRange::default(),
+        severity: Some(DiagnosticSeverity::ERROR),
+        code: Some(NumberOrString::String(RULE_ID_MAX_FILE_SIZE.to_string())),
+        code_description: None,
+        source: Some("veil".to_string()),
+        message: format!(
+            "Scan skipped because file size ({} bytes) exceeds limit ({} bytes)",
+            file_size_bytes, max_size_bytes
+        ),
+        related_information: None,
+        tags: None,
+        data: Some(json!({
+            "ruleId": RULE_ID_MAX_FILE_SIZE,
+            "score": 100,
+            "grade": Grade::Critical.to_string(),
+            "maskedSnippet": "",
+            "actions": [],
+            "skipReason": "maxFileSize",
+            "fileSizeBytes": file_size_bytes,
+            "maxSizeBytes": max_size_bytes,
         })),
     }
 }
@@ -59,7 +87,6 @@ mod tests {
     use std::path::PathBuf;
     use tower_lsp::lsp_types::{Position, Range as LspRange};
     use veil_core::model::{FindingSpan, Position as CorePosition};
-    use veil_core::rules::grade::Grade;
 
     fn finding_with(severity: Severity) -> Finding {
         Finding {
@@ -172,5 +199,40 @@ mod tests {
             Some(DiagnosticSeverity::INFORMATION)
         );
         assert_eq!(diagnostics[1].severity, Some(DiagnosticSeverity::ERROR));
+    }
+
+    #[test]
+    fn max_file_size_diagnostic_is_safe_and_explicitly_skipped() {
+        let diagnostic = max_file_size_diagnostic(1_500_000, 1_000_000);
+        let data = diagnostic.data.expect("diagnostic data");
+
+        assert_eq!(diagnostic.range, LspRange::default());
+        assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::ERROR));
+        assert_eq!(
+            diagnostic.code,
+            Some(NumberOrString::String(RULE_ID_MAX_FILE_SIZE.to_string()))
+        );
+        assert_eq!(
+            diagnostic.message,
+            "Scan skipped because file size (1500000 bytes) exceeds limit (1000000 bytes)"
+        );
+        assert_eq!(
+            data.get("skipReason").and_then(|value| value.as_str()),
+            Some("maxFileSize")
+        );
+        assert_eq!(
+            data.get("fileSizeBytes").and_then(|value| value.as_u64()),
+            Some(1_500_000)
+        );
+        assert_eq!(
+            data.get("maxSizeBytes").and_then(|value| value.as_u64()),
+            Some(1_000_000)
+        );
+        assert_eq!(
+            data.get("actions")
+                .and_then(|value| value.as_array())
+                .map(Vec::len),
+            Some(0)
+        );
     }
 }

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::diagnostics::findings_to_diagnostics;
+use crate::diagnostics::{findings_to_diagnostics, max_file_size_diagnostic};
 use crate::document_store::{DocumentState, DocumentStore};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
@@ -15,7 +15,7 @@ use tower_lsp::lsp_types::{
 };
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 use veil_config::Config;
-use veil_core::{scan_content, try_get_all_rules, Rule};
+use veil_core::{scan_content, try_get_all_rules, Rule, DEFAULT_MAX_FILE_SIZE_BYTES};
 
 const CHANGE_SCAN_DEBOUNCE: Duration = Duration::from_millis(200);
 
@@ -188,6 +188,15 @@ pub fn diagnostics_for_text(
     rules: &[Rule],
     config: &Config,
 ) -> Vec<Diagnostic> {
+    let max_size_bytes = config
+        .core
+        .max_file_size
+        .unwrap_or(DEFAULT_MAX_FILE_SIZE_BYTES);
+    let file_size_bytes = text.len() as u64;
+    if file_size_bytes > max_size_bytes {
+        return vec![max_file_size_diagnostic(file_size_bytes, max_size_bytes)];
+    }
+
     findings_to_diagnostics(&scan_content(text, path, rules, config))
 }
 
@@ -309,6 +318,36 @@ mod tests {
         let data_text = data.to_string();
         assert!(!data_text.contains("test@example.com"));
         assert!(!data_text.contains("🙂 contact test@example.com"));
+    }
+
+    #[test]
+    fn diagnostics_for_text_returns_max_file_size_skip_before_scanning() {
+        let mut config = Config::default();
+        config.core.max_file_size = Some(8);
+        let rules = try_get_all_rules(&config, Vec::new()).expect("rules");
+
+        let diagnostics = diagnostics_for_text(
+            "contact test@example.com\n",
+            Path::new("fixture.txt"),
+            &rules,
+            &config,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        let diagnostic = &diagnostics[0];
+        assert!(matches!(
+            diagnostic.code.as_ref(),
+            Some(NumberOrString::String(code)) if code == veil_core::RULE_ID_MAX_FILE_SIZE
+        ));
+        assert_eq!(diagnostic.range.start.line, 0);
+        assert_eq!(diagnostic.range.start.character, 0);
+        assert_eq!(diagnostic.range.end.line, 0);
+        assert_eq!(diagnostic.range.end.character, 0);
+
+        let data = diagnostic.data.as_ref().expect("diagnostic data");
+        let data_text = data.to_string();
+        assert!(!data_text.contains("test@example.com"));
+        assert!(!data_text.contains("contact test@example.com"));
     }
 
     #[test]

--- a/docs/design/enterprise_jp_pii/06_lsp_design.md
+++ b/docs/design/enterprise_jp_pii/06_lsp_design.md
@@ -88,6 +88,7 @@ struct DocumentStore {
 - `masked_snippet` は表示専用であり、Diagnostic rangeやCodeAction edit範囲に使わない。
 - Coreは normalized span を original byte span に戻し、LSP層で UTF-16 range に変換する。
 - LSP Diagnosticの `data` は `ruleId`, `score`, `grade`, `maskedSnippet`, `actions` のみ。raw値は載せない。
+- `MAX_FILE_SIZE` の skipped diagnostic はFinding由来ではないため、先頭 `0:0` range の synthetic diagnostic としてLSP層で生成する。
 
 ```rust
 pub struct Position {
@@ -161,6 +162,7 @@ vim.lsp.start({
 - [x] `didOpen` / `didChange` で `publishDiagnostics` を送る。
 - [x] `didClose` でdiagnosticsをclearする。
 - [x] `didChange` のscanを debounce し、同一documentの古い結果をpublishしない。
+- [x] open document が最大サイズ超過のとき `MAX_FILE_SIZE` skipped diagnostic を publish する。
 - [x] UTF-8 byte offset → UTF-16 LSP range変換はCoreの`Finding.utf16_range`に集約し、LSP Diagnosticでは再計算しない。
 - [ ] `codeAction` for mask/ignore。
 - [ ] 言語別ignore comment registryを実装。

--- a/docs/pr/PR-138-lsp-max-file-size-diagnostic.md
+++ b/docs/pr/PR-138-lsp-max-file-size-diagnostic.md
@@ -1,18 +1,18 @@
 ---
 release: TBD
 epic: A
-pr: TBD
-status: Draft
+pr: 138
+status: Ready
 created_at: 2026-07-08
 branch: feat/lsp-max-file-size-diagnostic
-commit: 6dde2b2840a96b64600779c9205f9870d28a87ef
+commit: a79e9f7ce3fdb72d1a000bf1f0806049ba4989f9
 title: Publish LSP max file size skip diagnostic
 ---
 
 ## SOT
 - Title: Publish LSP max file size skip diagnostic
-- Status: Draft
-- PR: TBD
+- Status: Ready
+- PR: #138
 
 ## What
 - [x] Publish a synthetic `MAX_FILE_SIZE` LSP diagnostic when an open document exceeds the scan size limit.

--- a/docs/pr/PR-TBD-lsp-max-file-size-diagnostic.md
+++ b/docs/pr/PR-TBD-lsp-max-file-size-diagnostic.md
@@ -1,0 +1,45 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: 2026-07-08
+branch: feat/lsp-max-file-size-diagnostic
+commit: 6dde2b2840a96b64600779c9205f9870d28a87ef
+title: Publish LSP max file size skip diagnostic
+---
+
+## SOT
+- Title: Publish LSP max file size skip diagnostic
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Publish a synthetic `MAX_FILE_SIZE` LSP diagnostic when an open document exceeds the scan size limit.
+- [x] Short-circuit LSP scanning before `scan_content` for oversized open documents.
+- [x] Keep `Finding.utf16_range` as the range source for regular findings.
+- [x] Keep raw document content out of skip diagnostic `data`.
+
+## Verification
+- [x] `cargo fmt --all`
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo test -p veil-lsp`
+- [x] `cargo test --workspace --lib --bins`
+- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [x] `git diff --check`
+
+## Evidence
+- `veil-lsp` tests passed: `16 passed; 0 failed`.
+- Workspace lib/bin tests passed across `veil-cli`, `veil-config`, `veil-core`, `veil-guardian`, `veil-lsp`, `veil-pro`, and `veil-server`.
+- Workspace clippy passed with `-D warnings`.
+- `diagnostics` tests cover safe `MAX_FILE_SIZE` diagnostic payload and zero-range placement.
+- `server` tests cover oversized text short-circuiting before normal finding scan.
+
+## Non-goals
+- [x] Do not change secret or PII finding mapping for non-skipped diagnostics.
+- [x] Do not implement code actions.
+- [x] Do not add preset/config file loading to LSP startup yet.
+- [x] Do not add binary/read-error skip diagnostics to LSP in this PR.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- publish a synthetic `MAX_FILE_SIZE` diagnostic for oversized open documents in the LSP server
- short-circuit before `scan_content` and keep regular finding ranges sourced from `Finding.utf16_range`
- keep raw document content out of diagnostic data and document the synthetic zero-range contract

## SOT
- `docs/pr/PR-138-lsp-max-file-size-diagnostic.md`

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p veil-lsp`
- `cargo test --workspace --lib --bins`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

## Non-goals
- no code actions
- no normal finding mapping changes
- no binary/read-error skip diagnostics yet