### PR TITLE
Add LSP UTF-16 range fixtures

### DIFF
--- a/crates/veil-lsp/tests/fixtures/utf16/email_emoji_prefix.txt
+++ b/crates/veil-lsp/tests/fixtures/utf16/email_emoji_prefix.txt
@@ -1,0 +1,8 @@
+# EXPECT_RULE: pii.net.email
+# EXPECT_LINE: 1
+# EXPECT_START: 11
+# EXPECT_END: 27
+# FORBID_DATA: test@example.com
+
+メモ
+🙂 contact test@example.com

--- a/crates/veil-lsp/tests/fixtures/utf16/email_fullwidth_prefix.txt
+++ b/crates/veil-lsp/tests/fixtures/utf16/email_fullwidth_prefix.txt
@@ -1,0 +1,7 @@
+# EXPECT_RULE: pii.net.email
+# EXPECT_LINE: 0
+# EXPECT_START: 4
+# EXPECT_END: 20
+# FORBID_DATA: test@example.com
+
+ＡＢＣ test@example.com

--- a/crates/veil-lsp/tests/utf16_range_fixture_test.rs
+++ b/crates/veil-lsp/tests/utf16_range_fixture_test.rs
@@ -1,0 +1,165 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::NumberOrString;
+use veil_config::Config;
+use veil_core::try_get_all_rules;
+use veil_lsp::server::diagnostics_for_text;
+
+#[test]
+fn lsp_diagnostics_follow_utf16_range_fixtures() {
+    let config = Config::default();
+    let rules = try_get_all_rules(&config, Vec::new()).expect("rules");
+
+    for fixture_path in fixture_paths() {
+        let (expectation, content) = load_fixture(&fixture_path);
+        let diagnostics = diagnostics_for_text(&content, &fixture_path, &rules, &config);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "fixture should produce exactly one diagnostic: {}",
+            fixture_path.display()
+        );
+
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| {
+                matches!(
+                    diagnostic.code.as_ref(),
+                    Some(NumberOrString::String(code)) if code == &expectation.rule_id
+                )
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected diagnostic '{}' in {}",
+                    expectation.rule_id,
+                    fixture_path.display()
+                )
+            });
+
+        assert_eq!(
+            diagnostic.range.start.line,
+            expectation.line,
+            "unexpected line for {}",
+            fixture_path.display()
+        );
+        assert_eq!(
+            diagnostic.range.start.character,
+            expectation.start_character,
+            "unexpected start character for {}",
+            fixture_path.display()
+        );
+        assert_eq!(
+            diagnostic.range.end.line,
+            expectation.line,
+            "unexpected end line for {}",
+            fixture_path.display()
+        );
+        assert_eq!(
+            diagnostic.range.end.character,
+            expectation.end_character,
+            "unexpected end character for {}",
+            fixture_path.display()
+        );
+
+        let data = diagnostic.data.as_ref().expect("diagnostic data");
+        let data_text = data.to_string();
+        assert!(
+            !data_text.contains(&expectation.forbidden_data),
+            "diagnostic data leaked raw match for {}",
+            fixture_path.display()
+        );
+        assert!(
+            !data_text.contains(content.trim()),
+            "diagnostic data leaked raw fixture body for {}",
+            fixture_path.display()
+        );
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct FixtureExpectation {
+    rule_id: String,
+    line: u32,
+    start_character: u32,
+    end_character: u32,
+    forbidden_data: String,
+}
+
+fn fixture_paths() -> Vec<PathBuf> {
+    let fixture_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("utf16");
+    let mut paths: Vec<_> = fs::read_dir(&fixture_dir)
+        .expect("fixture dir")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("txt"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn load_fixture(path: &Path) -> (FixtureExpectation, String) {
+    let fixture = fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read fixture {}: {error}", path.display()));
+    let mut rule_id = None;
+    let mut line = None;
+    let mut start_character = None;
+    let mut end_character = None;
+    let mut forbidden_data = None;
+    let mut body_lines = Vec::new();
+    let mut in_body = false;
+
+    for raw_line in fixture.lines() {
+        if in_body {
+            body_lines.push(raw_line);
+            continue;
+        }
+
+        if raw_line.trim().is_empty() {
+            in_body = true;
+            continue;
+        }
+
+        if let Some(value) = raw_line.strip_prefix("# EXPECT_RULE:") {
+            rule_id = Some(value.trim().to_string());
+            continue;
+        }
+        if let Some(value) = raw_line.strip_prefix("# EXPECT_LINE:") {
+            line = Some(value.trim().parse::<u32>().expect("EXPECT_LINE"));
+            continue;
+        }
+        if let Some(value) = raw_line.strip_prefix("# EXPECT_START:") {
+            start_character = Some(value.trim().parse::<u32>().expect("EXPECT_START"));
+            continue;
+        }
+        if let Some(value) = raw_line.strip_prefix("# EXPECT_END:") {
+            end_character = Some(value.trim().parse::<u32>().expect("EXPECT_END"));
+            continue;
+        }
+        if let Some(value) = raw_line.strip_prefix("# FORBID_DATA:") {
+            forbidden_data = Some(value.trim().to_string());
+            continue;
+        }
+
+        panic!(
+            "unsupported fixture metadata line in {}: {}",
+            path.display(),
+            raw_line
+        );
+    }
+
+    (
+        FixtureExpectation {
+            rule_id: rule_id.expect("EXPECT_RULE"),
+            line: line.expect("EXPECT_LINE"),
+            start_character: start_character.expect("EXPECT_START"),
+            end_character: end_character.expect("EXPECT_END"),
+            forbidden_data: forbidden_data.expect("FORBID_DATA"),
+        },
+        body_lines.join("\n"),
+    )
+}

--- a/docs/pr/PR-139-lsp-utf16-range-fixture.md
+++ b/docs/pr/PR-139-lsp-utf16-range-fixture.md
@@ -1,18 +1,18 @@
 ---
 release: TBD
 epic: A
-pr: TBD
-status: Draft
+pr: 139
+status: Ready
 created_at: 2026-07-08
 branch: feat/lsp-utf16-range-fixture
-commit: ee8c88b908d6537439c9f6e28c01576ab26e4566
+commit: 2865d3b13ce0cd4618b35d93d9d3f97be3629d2f
 title: Add LSP UTF-16 range fixtures
 ---
 
 ## SOT
 - Title: Add LSP UTF-16 range fixtures
-- Status: Draft
-- PR: TBD
+- Status: Ready
+- PR: #139
 
 ## What
 - [x] Add fixture-driven `veil-lsp` tests for UTF-16 diagnostic ranges.

--- a/docs/pr/PR-TBD-lsp-utf16-range-fixture.md
+++ b/docs/pr/PR-TBD-lsp-utf16-range-fixture.md
@@ -1,0 +1,37 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: 2026-07-08
+branch: feat/lsp-utf16-range-fixture
+commit: ee8c88b908d6537439c9f6e28c01576ab26e4566
+title: Add LSP UTF-16 range fixtures
+---
+
+## SOT
+- Title: Add LSP UTF-16 range fixtures
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add fixture-driven `veil-lsp` tests for UTF-16 diagnostic ranges.
+- [x] Cover emoji-prefixed and fullwidth-prefixed email diagnostics.
+- [x] Assert that diagnostic `data` remains raw-free while range positions stay UTF-16-based.
+
+## Verification
+- [x] `cargo fmt --all`
+- [x] `cargo test -p veil-lsp`
+- [x] `cargo test --workspace --lib --bins`
+- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [x] `git diff --check`
+
+## Non-goals
+- [x] Do not add code actions.
+- [x] Do not change LSP publish behavior.
+- [x] Do not introduce disk-based binary or read-error classification into LSP.
+
+## Evidence
+- `veil-lsp` tests passed with the new fixture-driven UTF-16 range contract test.
+- Workspace lib/bin tests passed across `veil-cli`, `veil-config`, `veil-core`, `veil-guardian`, `veil-lsp`, `veil-pro`, and `veil-server`.
+- Workspace clippy passed with `-D warnings`.


### PR DESCRIPTION
## Summary
- add fixture-driven `veil-lsp` tests for UTF-16 diagnostic ranges
- cover emoji-prefixed and fullwidth-prefixed email diagnostics so byte offsets cannot accidentally leak into LSP ranges
- assert that diagnostic `data` stays raw-free while range positions remain UTF-16-based

## SOT
- `docs/pr/PR-139-lsp-utf16-range-fixture.md`

## Verification
- `cargo fmt --all`
- `cargo test -p veil-lsp`
- `cargo test --workspace --lib --bins`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

## Non-goals
- no code actions
- no LSP publish behavior changes
- no disk-based binary/read-error classification in LSP