### PR TITLE
Add LSP mask code action

### DIFF
--- a/crates/veil-lsp/src/code_actions.rs
+++ b/crates/veil-lsp/src/code_actions.rs
@@ -1,1 +1,152 @@
+use std::collections::HashMap;
 
+use tower_lsp::lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, Diagnostic, NumberOrString, TextEdit, Url,
+    WorkspaceEdit,
+};
+use veil_core::DEFAULT_PLACEHOLDER;
+
+use crate::document_store::byte_range_for_lsp_range;
+
+pub fn mask_code_actions(
+    uri: &Url,
+    text: &str,
+    diagnostics: &[Diagnostic],
+) -> Vec<CodeActionOrCommand> {
+    diagnostics
+        .iter()
+        .filter_map(|diagnostic| mask_code_action(uri, text, diagnostic))
+        .map(CodeActionOrCommand::CodeAction)
+        .collect()
+}
+
+fn mask_code_action(uri: &Url, text: &str, diagnostic: &Diagnostic) -> Option<CodeAction> {
+    if !supports_mask_action(diagnostic) {
+        return None;
+    }
+
+    let byte_range = byte_range_for_lsp_range(text, diagnostic.range)?;
+    if byte_range.is_empty() || text.get(byte_range) == Some(DEFAULT_PLACEHOLDER) {
+        return None;
+    }
+
+    Some(CodeAction {
+        title: "Mask value".to_string(),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(HashMap::from([(
+                uri.clone(),
+                vec![TextEdit {
+                    range: diagnostic.range,
+                    new_text: DEFAULT_PLACEHOLDER.to_string(),
+                }],
+            )])),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: Some(true),
+        disabled: None,
+        data: None,
+    })
+}
+
+fn supports_mask_action(diagnostic: &Diagnostic) -> bool {
+    diagnostic
+        .data
+        .as_ref()
+        .and_then(|data| data.get("actions"))
+        .and_then(|actions| actions.as_array())
+        .is_some_and(|actions| {
+            actions
+                .iter()
+                .any(|action| action.as_str().is_some_and(|action| action == "mask"))
+        })
+        && matches!(diagnostic.code.as_ref(), Some(NumberOrString::String(_)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tower_lsp::lsp_types::{NumberOrString, Position, Range};
+
+    fn finding_diagnostic() -> Diagnostic {
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 8,
+                },
+                end: Position {
+                    line: 0,
+                    character: 24,
+                },
+            },
+            severity: None,
+            code: Some(NumberOrString::String("secret.test".to_string())),
+            code_description: None,
+            source: Some("veil".to_string()),
+            message: "Sensitive data detected".to_string(),
+            related_information: None,
+            tags: None,
+            data: Some(json!({
+                "ruleId": "secret.test",
+                "score": 92,
+                "grade": "CRITICAL",
+                "maskedSnippet": "token = <REDACTED>",
+                "actions": ["mask", "ignore"],
+            })),
+        }
+    }
+
+    #[test]
+    fn mask_code_actions_return_quickfix_edit() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+        let diagnostics =
+            mask_code_actions(&uri, "token = raw-secret-value", &[finding_diagnostic()]);
+
+        assert_eq!(diagnostics.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &diagnostics[0] else {
+            panic!("expected code action");
+        };
+
+        assert_eq!(action.title, "Mask value");
+        assert_eq!(action.kind, Some(CodeActionKind::QUICKFIX));
+        let edit = action.edit.as_ref().expect("workspace edit");
+        let changes = edit.changes.as_ref().expect("text edits");
+        let text_edits = changes.get(&uri).expect("uri edits");
+        assert_eq!(text_edits.len(), 1);
+        assert_eq!(text_edits[0].range, finding_diagnostic().range);
+        assert_eq!(text_edits[0].new_text, DEFAULT_PLACEHOLDER);
+    }
+
+    #[test]
+    fn mask_code_actions_ignore_skip_diagnostics() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+        let diagnostic = Diagnostic {
+            range: Range::default(),
+            severity: None,
+            code: Some(NumberOrString::String("MAX_FILE_SIZE".to_string())),
+            code_description: None,
+            source: Some("veil".to_string()),
+            message: "Scan skipped".to_string(),
+            related_information: None,
+            tags: None,
+            data: Some(json!({
+                "ruleId": "MAX_FILE_SIZE",
+                "actions": [],
+            })),
+        };
+
+        assert!(mask_code_actions(&uri, "oversized", &[diagnostic]).is_empty());
+    }
+
+    #[test]
+    fn mask_code_actions_ignore_already_redacted_ranges() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+
+        assert!(mask_code_actions(&uri, "token = <REDACTED>", &[finding_diagnostic()]).is_empty());
+    }
+}

--- a/crates/veil-lsp/src/document_store.rs
+++ b/crates/veil-lsp/src/document_store.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::ops::Range;
 
 use tower_lsp::lsp_types::{
     Position as LspPosition, Range as LspRange, TextDocumentContentChangeEvent, Url,
@@ -90,18 +91,18 @@ fn apply_content_change(
         return Ok(());
     };
 
-    let Some(start) = byte_index_for_position(text, range.start) else {
+    let Some(byte_range) = byte_range_for_lsp_range(text, range) else {
         return Err(DocumentChangeError::InvalidRange { range });
     };
-    let Some(end) = byte_index_for_position(text, range.end) else {
-        return Err(DocumentChangeError::InvalidRange { range });
-    };
-    if start > end {
-        return Err(DocumentChangeError::InvalidRange { range });
-    }
 
-    text.replace_range(start..end, &change.text);
+    text.replace_range(byte_range, &change.text);
     Ok(())
+}
+
+pub fn byte_range_for_lsp_range(text: &str, range: LspRange) -> Option<Range<usize>> {
+    let start = byte_index_for_position(text, range.start)?;
+    let end = byte_index_for_position(text, range.end)?;
+    (start <= end).then_some(start..end)
 }
 
 fn byte_index_for_position(text: &str, position: LspPosition) -> Option<usize> {

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -5,11 +5,13 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::code_actions::mask_code_actions;
 use crate::diagnostics::{findings_to_diagnostics, max_file_size_diagnostic};
 use crate::document_store::{DocumentState, DocumentStore};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
-    Diagnostic, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    CodeActionParams, CodeActionProviderCapability, CodeActionResponse, Diagnostic,
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     InitializeParams, InitializeResult, InitializedParams, MessageType, ServerCapabilities,
     ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind, Url,
 };
@@ -160,6 +162,24 @@ impl LanguageServer for Backend {
         self.client.publish_diagnostics(uri, Vec::new(), None).await;
     }
 
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        let uri = params.text_document.uri;
+        let document = {
+            let documents = self.documents.lock().await;
+            documents.get(&uri)
+        };
+        let Some(document) = document else {
+            return Ok(None);
+        };
+
+        let actions = mask_code_actions(&uri, &document.text, &params.context.diagnostics);
+        if actions.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(actions))
+    }
+
     async fn shutdown(&self) -> Result<()> {
         Ok(())
     }
@@ -178,6 +198,7 @@ pub fn server_capabilities() -> ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
             TextDocumentSyncKind::INCREMENTAL,
         )),
+        code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         ..ServerCapabilities::default()
     }
 }
@@ -268,7 +289,10 @@ fn document_for_revision(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString, TextDocumentSyncCapability};
+    use tower_lsp::lsp_types::{
+        CodeActionProviderCapability, DiagnosticSeverity, NumberOrString,
+        TextDocumentSyncCapability,
+    };
 
     #[test]
     fn server_name_matches_binary_name() {
@@ -286,7 +310,10 @@ mod tests {
             ))
         );
         assert!(capabilities.diagnostic_provider.is_none());
-        assert!(capabilities.code_action_provider.is_none());
+        assert_eq!(
+            capabilities.code_action_provider,
+            Some(CodeActionProviderCapability::Simple(true))
+        );
     }
 
     #[test]

--- a/docs/design/enterprise_jp_pii/06_lsp_design.md
+++ b/docs/design/enterprise_jp_pii/06_lsp_design.md
@@ -134,6 +134,8 @@ pub struct LspFinding {
 | SQL | `--` | `-- veil:ignore=...` |
 | JSON | なし | inline ignore actionを出さない |
 
+現在の実装は staged rollout とし、まず `Mask value` の quick fix のみを配線する。`Partial mask` と `Add inline ignore` は follow-up とする。
+
 ### 安全ルール
 - CodeActionは自動適用しない。
 - raw matched_content は `data` に載せない。

--- a/docs/pr/PR-140-lsp-mask-code-action.md
+++ b/docs/pr/PR-140-lsp-mask-code-action.md
@@ -1,18 +1,18 @@
 ---
 release: TBD
 epic: A
-pr: TBD
-status: Draft
+pr: 140
+status: Ready
 created_at: 2026-07-08
 branch: feat/lsp-mask-code-action
-commit: 6c56f8b2b242abc7b1f280d918f8aaf0d0cfd041
+commit: 039405cfadb42ae50f8e57c61d3cdad5672875dc
 title: Add LSP mask code action
 ---
 
 ## SOT
 - Title: Add LSP mask code action
-- Status: Draft
-- PR: TBD
+- Status: Ready
+- PR: #140
 
 ## What
 - [x] Wire a minimal LSP `Mask value` code action for finding diagnostics.

--- a/docs/pr/PR-TBD-lsp-mask-code-action.md
+++ b/docs/pr/PR-TBD-lsp-mask-code-action.md
@@ -1,0 +1,38 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: 2026-07-08
+branch: feat/lsp-mask-code-action
+commit: 6c56f8b2b242abc7b1f280d918f8aaf0d0cfd041
+title: Add LSP mask code action
+---
+
+## SOT
+- Title: Add LSP mask code action
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Wire a minimal LSP `Mask value` code action for finding diagnostics.
+- [x] Reuse the diagnostic UTF-16 range as the only edit range source.
+- [x] Suppress mask actions for skip diagnostics and already-redacted selections.
+- [x] Advertise `code_action_provider` in server capabilities.
+
+## Verification
+- [x] `cargo fmt --all`
+- [x] `cargo test -p veil-lsp`
+- [x] `cargo test --workspace --lib --bins`
+- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [x] `git diff --check`
+
+## Non-goals
+- [x] Do not implement partial mask.
+- [x] Do not implement inline ignore comments.
+- [x] Do not change LSP diagnostics payload shape.
+
+## Evidence
+- `veil-lsp` tests passed with new mask code action coverage and existing UTF-16 fixture coverage.
+- Workspace lib/bin tests passed across `veil-cli`, `veil-config`, `veil-core`, `veil-guardian`, `veil-lsp`, `veil-pro`, and `veil-server`.
+- Workspace clippy passed with `-D warnings`.


### PR DESCRIPTION
## Summary
- wire a minimal `Mask value` LSP code action for finding diagnostics
- reuse the diagnostic UTF-16 range as the only edit range source and advertise `code_action_provider`
- suppress mask actions for skip diagnostics and already-redacted selections while leaving partial mask and inline ignore for follow-up PRs

## SOT
- `docs/pr/PR-140-lsp-mask-code-action.md`

## Verification
- `cargo fmt --all`
- `cargo test -p veil-lsp`
- `cargo test --workspace --lib --bins`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

## Non-goals
- no partial mask
- no inline ignore comments
- no diagnostic payload changes
