### PR TITLE
Add LSP inline ignore code action

### DIFF
--- a/crates/veil-lsp/src/code_actions.rs
+++ b/crates/veil-lsp/src/code_actions.rs
@@ -1,27 +1,35 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use tower_lsp::lsp_types::{
-    CodeAction, CodeActionKind, CodeActionOrCommand, Diagnostic, NumberOrString, TextEdit, Url,
-    WorkspaceEdit,
+    CodeAction, CodeActionKind, CodeActionOrCommand, Diagnostic, NumberOrString, Position,
+    TextEdit, Url, WorkspaceEdit,
 };
 use veil_core::DEFAULT_PLACEHOLDER;
 
-use crate::document_store::byte_range_for_lsp_range;
+use crate::document_store::{byte_range_for_lsp_range, line_byte_bounds};
 
-pub fn mask_code_actions(
+pub fn code_actions(
     uri: &Url,
+    language_id: &str,
     text: &str,
     diagnostics: &[Diagnostic],
 ) -> Vec<CodeActionOrCommand> {
     diagnostics
         .iter()
-        .filter_map(|diagnostic| mask_code_action(uri, text, diagnostic))
+        .flat_map(|diagnostic| {
+            [
+                mask_code_action(uri, text, diagnostic),
+                inline_ignore_code_action(uri, language_id, text, diagnostic),
+            ]
+        })
+        .flatten()
         .map(CodeActionOrCommand::CodeAction)
         .collect()
 }
 
 fn mask_code_action(uri: &Url, text: &str, diagnostic: &Diagnostic) -> Option<CodeAction> {
-    if !supports_mask_action(diagnostic) {
+    if !supports_action(diagnostic, "mask") {
         return None;
     }
 
@@ -34,17 +42,11 @@ fn mask_code_action(uri: &Url, text: &str, diagnostic: &Diagnostic) -> Option<Co
         title: "Mask value".to_string(),
         kind: Some(CodeActionKind::QUICKFIX),
         diagnostics: Some(vec![diagnostic.clone()]),
-        edit: Some(WorkspaceEdit {
-            changes: Some(HashMap::from([(
-                uri.clone(),
-                vec![TextEdit {
-                    range: diagnostic.range,
-                    new_text: DEFAULT_PLACEHOLDER.to_string(),
-                }],
-            )])),
-            document_changes: None,
-            change_annotations: None,
-        }),
+        edit: Some(workspace_edit(
+            uri,
+            diagnostic.range,
+            DEFAULT_PLACEHOLDER.to_string(),
+        )),
         command: None,
         is_preferred: Some(true),
         disabled: None,
@@ -52,7 +54,69 @@ fn mask_code_action(uri: &Url, text: &str, diagnostic: &Diagnostic) -> Option<Co
     })
 }
 
-fn supports_mask_action(diagnostic: &Diagnostic) -> bool {
+fn inline_ignore_code_action(
+    uri: &Url,
+    language_id: &str,
+    text: &str,
+    diagnostic: &Diagnostic,
+) -> Option<CodeAction> {
+    if !supports_action(diagnostic, "ignore") {
+        return None;
+    }
+
+    let rule_id = match diagnostic.code.as_ref() {
+        Some(NumberOrString::String(rule_id)) => rule_id.as_str(),
+        _ => return None,
+    };
+
+    let comment_style = comment_style_for_document(uri, language_id)?;
+    let (line_start, line_end) = line_byte_bounds(text, diagnostic.range.start.line)?;
+    let line_text = &text[line_start..line_end];
+    if line_text.contains("veil:ignore") {
+        return None;
+    }
+
+    let insertion = comment_style.render(rule_id);
+    let range = Position {
+        line: diagnostic.range.start.line,
+        character: utf16_len(line_text),
+    };
+
+    Some(CodeAction {
+        title: "Add inline ignore".to_string(),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(workspace_edit(uri, range_to_insertion(range), insertion)),
+        command: None,
+        is_preferred: Some(false),
+        disabled: None,
+        data: None,
+    })
+}
+
+fn workspace_edit(
+    uri: &Url,
+    range: tower_lsp::lsp_types::Range,
+    new_text: String,
+) -> WorkspaceEdit {
+    WorkspaceEdit {
+        changes: Some(HashMap::from([(
+            uri.clone(),
+            vec![TextEdit { range, new_text }],
+        )])),
+        document_changes: None,
+        change_annotations: None,
+    }
+}
+
+fn range_to_insertion(position: Position) -> tower_lsp::lsp_types::Range {
+    tower_lsp::lsp_types::Range {
+        start: position,
+        end: position,
+    }
+}
+
+fn supports_action(diagnostic: &Diagnostic, action_name: &str) -> bool {
     diagnostic
         .data
         .as_ref()
@@ -61,16 +125,83 @@ fn supports_mask_action(diagnostic: &Diagnostic) -> bool {
         .is_some_and(|actions| {
             actions
                 .iter()
-                .any(|action| action.as_str().is_some_and(|action| action == "mask"))
+                .any(|action| action.as_str().is_some_and(|action| action == action_name))
         })
         && matches!(diagnostic.code.as_ref(), Some(NumberOrString::String(_)))
+}
+
+fn utf16_len(text: &str) -> u32 {
+    text.chars()
+        .map(|character| character.len_utf16() as u32)
+        .sum()
+}
+
+fn comment_style_for_document(uri: &Url, language_id: &str) -> Option<CommentStyle> {
+    comment_style_for_language_id(language_id).or_else(|| {
+        Path::new(uri.path())
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .and_then(comment_style_for_extension)
+    })
+}
+
+fn comment_style_for_language_id(language_id: &str) -> Option<CommentStyle> {
+    match language_id {
+        "rust" | "go" | "javascript" | "javascriptreact" | "typescript" | "typescriptreact"
+        | "java" | "c" | "cpp" | "objective-c" | "objective-cpp" => Some(CommentStyle::Line("//")),
+        "python" | "ruby" | "shellscript" | "yaml" | "toml" => Some(CommentStyle::Line("#")),
+        "html" | "xml" => Some(CommentStyle::Block {
+            start: "<!--",
+            end: "-->",
+        }),
+        "sql" => Some(CommentStyle::Line("--")),
+        "json" | "jsonc" => None,
+        _ => None,
+    }
+}
+
+fn comment_style_for_extension(extension: &str) -> Option<CommentStyle> {
+    match extension {
+        "rs" | "go" | "js" | "jsx" | "ts" | "tsx" | "java" | "c" | "cc" | "cpp" | "cxx" | "h"
+        | "hpp" | "m" | "mm" => Some(CommentStyle::Line("//")),
+        "py" | "rb" | "sh" | "bash" | "zsh" | "yml" | "yaml" | "toml" => {
+            Some(CommentStyle::Line("#"))
+        }
+        "html" | "htm" | "xml" | "svg" => Some(CommentStyle::Block {
+            start: "<!--",
+            end: "-->",
+        }),
+        "sql" => Some(CommentStyle::Line("--")),
+        "json" => None,
+        _ => None,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CommentStyle {
+    Line(&'static str),
+    Block {
+        start: &'static str,
+        end: &'static str,
+    },
+}
+
+impl CommentStyle {
+    fn render(self, rule_id: &str) -> String {
+        match self {
+            CommentStyle::Line(prefix) => format!(" {prefix} veil:ignore={rule_id}"),
+            CommentStyle::Block { start, end } => {
+                format!(" {start} veil:ignore={rule_id} {end}")
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
-    use tower_lsp::lsp_types::{NumberOrString, Position, Range};
+    use tower_lsp::lsp_types::{NumberOrString, Range};
 
     fn finding_diagnostic() -> Diagnostic {
         Diagnostic {
@@ -102,28 +233,86 @@ mod tests {
     }
 
     #[test]
-    fn mask_code_actions_return_quickfix_edit() {
-        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
-        let diagnostics =
-            mask_code_actions(&uri, "token = raw-secret-value", &[finding_diagnostic()]);
+    fn code_actions_return_mask_and_inline_ignore_for_rust() {
+        let uri = Url::parse("file:///tmp/example.rs").expect("uri");
+        let diagnostics = code_actions(
+            &uri,
+            "rust",
+            "token = raw-secret-value",
+            &[finding_diagnostic()],
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+
+        let CodeActionOrCommand::CodeAction(mask_action) = &diagnostics[0] else {
+            panic!("expected code action");
+        };
+        assert_eq!(mask_action.title, "Mask value");
+        let mask_edit = mask_action.edit.as_ref().expect("workspace edit");
+        let mask_changes = mask_edit.changes.as_ref().expect("text edits");
+        let mask_text_edits = mask_changes.get(&uri).expect("uri edits");
+        assert_eq!(mask_text_edits[0].range, finding_diagnostic().range);
+        assert_eq!(mask_text_edits[0].new_text, DEFAULT_PLACEHOLDER);
+
+        let CodeActionOrCommand::CodeAction(ignore_action) = &diagnostics[1] else {
+            panic!("expected code action");
+        };
+        assert_eq!(ignore_action.title, "Add inline ignore");
+        let ignore_edit = ignore_action.edit.as_ref().expect("workspace edit");
+        let ignore_changes = ignore_edit.changes.as_ref().expect("text edits");
+        let ignore_text_edits = ignore_changes.get(&uri).expect("uri edits");
+        assert_eq!(
+            ignore_text_edits[0].range,
+            Range {
+                start: Position {
+                    line: 0,
+                    character: 24,
+                },
+                end: Position {
+                    line: 0,
+                    character: 24,
+                },
+            }
+        );
+        assert_eq!(ignore_text_edits[0].new_text, " // veil:ignore=secret.test");
+    }
+
+    #[test]
+    fn code_actions_hide_inline_ignore_for_json() {
+        let uri = Url::parse("file:///tmp/example.json").expect("uri");
+        let diagnostics = code_actions(
+            &uri,
+            "json",
+            "token = raw-secret-value",
+            &[finding_diagnostic()],
+        );
 
         assert_eq!(diagnostics.len(), 1);
         let CodeActionOrCommand::CodeAction(action) = &diagnostics[0] else {
             panic!("expected code action");
         };
-
         assert_eq!(action.title, "Mask value");
-        assert_eq!(action.kind, Some(CodeActionKind::QUICKFIX));
-        let edit = action.edit.as_ref().expect("workspace edit");
-        let changes = edit.changes.as_ref().expect("text edits");
-        let text_edits = changes.get(&uri).expect("uri edits");
-        assert_eq!(text_edits.len(), 1);
-        assert_eq!(text_edits[0].range, finding_diagnostic().range);
-        assert_eq!(text_edits[0].new_text, DEFAULT_PLACEHOLDER);
     }
 
     #[test]
-    fn mask_code_actions_ignore_skip_diagnostics() {
+    fn code_actions_hide_inline_ignore_when_line_already_contains_ignore() {
+        let uri = Url::parse("file:///tmp/example.rs").expect("uri");
+        let diagnostics = code_actions(
+            &uri,
+            "rust",
+            "token = raw-secret-value // veil:ignore=secret.test",
+            &[finding_diagnostic()],
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &diagnostics[0] else {
+            panic!("expected code action");
+        };
+        assert_eq!(action.title, "Mask value");
+    }
+
+    #[test]
+    fn code_actions_ignore_skip_diagnostics() {
         let uri = Url::parse("file:///tmp/example.txt").expect("uri");
         let diagnostic = Diagnostic {
             range: Range::default(),
@@ -140,13 +329,18 @@ mod tests {
             })),
         };
 
-        assert!(mask_code_actions(&uri, "oversized", &[diagnostic]).is_empty());
+        assert!(code_actions(&uri, "text", "oversized", &[diagnostic]).is_empty());
     }
 
     #[test]
-    fn mask_code_actions_ignore_already_redacted_ranges() {
-        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+    fn code_actions_ignore_already_redacted_ranges() {
+        let uri = Url::parse("file:///tmp/example.rs").expect("uri");
+        let diagnostics = code_actions(&uri, "rust", "token = <REDACTED>", &[finding_diagnostic()]);
 
-        assert!(mask_code_actions(&uri, "token = <REDACTED>", &[finding_diagnostic()]).is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &diagnostics[0] else {
+            panic!("expected code action");
+        };
+        assert_eq!(action.title, "Add inline ignore");
     }
 }

--- a/crates/veil-lsp/src/document_store.rs
+++ b/crates/veil-lsp/src/document_store.rs
@@ -9,6 +9,7 @@ use tower_lsp::lsp_types::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DocumentState {
     pub uri: Url,
+    pub language_id: String,
     pub text: String,
     pub version: i32,
     pub scan_revision: u64,
@@ -20,9 +21,16 @@ pub struct DocumentStore {
 }
 
 impl DocumentStore {
-    pub fn open(&mut self, uri: Url, text: String, version: i32) -> DocumentState {
+    pub fn open(
+        &mut self,
+        uri: Url,
+        language_id: String,
+        text: String,
+        version: i32,
+    ) -> DocumentState {
         let document = DocumentState {
             uri: uri.clone(),
+            language_id,
             text,
             version,
             scan_revision: 0,
@@ -105,30 +113,7 @@ pub fn byte_range_for_lsp_range(text: &str, range: LspRange) -> Option<Range<usi
     (start <= end).then_some(start..end)
 }
 
-fn byte_index_for_position(text: &str, position: LspPosition) -> Option<usize> {
-    let (line_start, line_end) = line_byte_bounds(text, position.line)?;
-    let line = &text[line_start..line_end];
-
-    if position.character == 0 {
-        return Some(line_start);
-    }
-
-    let mut utf16_units = 0_u32;
-    for (byte_offset, character) in line.char_indices() {
-        if utf16_units == position.character {
-            return Some(line_start + byte_offset);
-        }
-
-        utf16_units = utf16_units.saturating_add(character.len_utf16() as u32);
-        if utf16_units > position.character {
-            return None;
-        }
-    }
-
-    (utf16_units == position.character).then_some(line_end)
-}
-
-fn line_byte_bounds(text: &str, target_line: u32) -> Option<(usize, usize)> {
+pub fn line_byte_bounds(text: &str, target_line: u32) -> Option<(usize, usize)> {
     let mut line = 0_u32;
     let mut line_start = 0_usize;
 
@@ -151,6 +136,29 @@ fn line_byte_bounds(text: &str, target_line: u32) -> Option<(usize, usize)> {
     }
 
     (line == target_line).then_some((line_start, text.len()))
+}
+
+fn byte_index_for_position(text: &str, position: LspPosition) -> Option<usize> {
+    let (line_start, line_end) = line_byte_bounds(text, position.line)?;
+    let line = &text[line_start..line_end];
+
+    if position.character == 0 {
+        return Some(line_start);
+    }
+
+    let mut utf16_units = 0_u32;
+    for (byte_offset, character) in line.char_indices() {
+        if utf16_units == position.character {
+            return Some(line_start + byte_offset);
+        }
+
+        utf16_units = utf16_units.saturating_add(character.len_utf16() as u32);
+        if utf16_units > position.character {
+            return None;
+        }
+    }
+
+    (utf16_units == position.character).then_some(line_end)
 }
 
 #[cfg(test)]
@@ -178,7 +186,7 @@ mod tests {
     fn store_applies_full_document_changes() {
         let uri = Url::parse("file:///tmp/example.txt").expect("uri");
         let mut store = DocumentStore::default();
-        store.open(uri.clone(), "before".to_string(), 1);
+        store.open(uri.clone(), "text".to_string(), "before".to_string(), 1);
 
         let document = store
             .apply_changes(&uri, 2, vec![full_change("after")])
@@ -194,7 +202,7 @@ mod tests {
     fn store_applies_incremental_changes_with_utf16_positions() {
         let uri = Url::parse("file:///tmp/example.txt").expect("uri");
         let mut store = DocumentStore::default();
-        store.open(uri.clone(), "a🙂c".to_string(), 1);
+        store.open(uri.clone(), "text".to_string(), "a🙂c".to_string(), 1);
 
         let document = store
             .apply_changes(
@@ -225,7 +233,7 @@ mod tests {
     fn store_rejects_positions_inside_utf16_surrogate_pairs() {
         let uri = Url::parse("file:///tmp/example.txt").expect("uri");
         let mut store = DocumentStore::default();
-        store.open(uri.clone(), "a🙂c".to_string(), 1);
+        store.open(uri.clone(), "text".to_string(), "a🙂c".to_string(), 1);
 
         let result = store.apply_changes(
             &uri,
@@ -256,8 +264,9 @@ mod tests {
         let uri = Url::parse("file:///tmp/example.txt").expect("uri");
         let mut store = DocumentStore::default();
 
-        let original = store.open(uri.clone(), "before".to_string(), 1);
+        let original = store.open(uri.clone(), "rust".to_string(), "before".to_string(), 1);
         assert_eq!(original.scan_revision, 0);
+        assert_eq!(original.language_id, "rust");
 
         let updated = store
             .apply_changes(&uri, 2, vec![full_change("after")])
@@ -265,7 +274,7 @@ mod tests {
             .expect("document");
         assert_eq!(updated.scan_revision, 1);
 
-        let reopened = store.open(uri, "reopened".to_string(), 1);
+        let reopened = store.open(uri, "rust".to_string(), "reopened".to_string(), 1);
         assert_eq!(reopened.scan_revision, 0);
     }
 
@@ -273,7 +282,7 @@ mod tests {
     fn has_revision_tracks_latest_document_generation() {
         let uri = Url::parse("file:///tmp/example.txt").expect("uri");
         let mut store = DocumentStore::default();
-        store.open(uri.clone(), "before".to_string(), 1);
+        store.open(uri.clone(), "text".to_string(), "before".to_string(), 1);
 
         let updated = store
             .apply_changes(&uri, 2, vec![full_change("after")])

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::code_actions::mask_code_actions;
+use crate::code_actions::code_actions;
 use crate::diagnostics::{findings_to_diagnostics, max_file_size_diagnostic};
 use crate::document_store::{DocumentState, DocumentStore};
 use tower_lsp::jsonrpc::Result;
@@ -116,7 +116,12 @@ impl LanguageServer for Backend {
         let text_document = params.text_document;
         let document = {
             let mut documents = self.documents.lock().await;
-            documents.open(text_document.uri, text_document.text, text_document.version)
+            documents.open(
+                text_document.uri,
+                text_document.language_id,
+                text_document.text,
+                text_document.version,
+            )
         };
 
         self.schedule_document_diagnostics(document, Duration::ZERO)
@@ -172,7 +177,12 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
 
-        let actions = mask_code_actions(&uri, &document.text, &params.context.diagnostics);
+        let actions = code_actions(
+            &uri,
+            &document.language_id,
+            &document.text,
+            &params.context.diagnostics,
+        );
         if actions.is_empty() {
             return Ok(None);
         }
@@ -386,7 +396,7 @@ mod tests {
     fn document_for_revision_requires_latest_scan_revision() {
         let uri = Url::parse("file:///tmp/example.txt").expect("uri");
         let mut documents = DocumentStore::default();
-        documents.open(uri.clone(), "before".to_string(), 1);
+        documents.open(uri.clone(), "text".to_string(), "before".to_string(), 1);
         let current = documents
             .apply_changes(
                 &uri,

--- a/docs/design/enterprise_jp_pii/06_lsp_design.md
+++ b/docs/design/enterprise_jp_pii/06_lsp_design.md
@@ -134,7 +134,7 @@ pub struct LspFinding {
 | SQL | `--` | `-- veil:ignore=...` |
 | JSON | なし | inline ignore actionを出さない |
 
-現在の実装は staged rollout とし、まず `Mask value` の quick fix のみを配線する。`Partial mask` と `Add inline ignore` は follow-up とする。
+現在の実装は staged rollout とし、`Mask value` と `Add inline ignore` の quick fix を配線する。`Partial mask` は follow-up とする。
 
 ### 安全ルール
 - CodeActionは自動適用しない。

--- a/docs/pr/PR-141-lsp-inline-ignore-action.md
+++ b/docs/pr/PR-141-lsp-inline-ignore-action.md
@@ -1,18 +1,18 @@
 ---
 release: TBD
 epic: A
-pr: TBD
-status: Draft
+pr: 141
+status: Ready
 created_at: 2026-07-08
 branch: feat/lsp-inline-ignore-action
-commit: 8772577c8b9f1895aa3e6d13e8878df420200cd5
+commit: f4fa434009607d912c1dd8f9e7adffe497a8f059
 title: Add LSP inline ignore code action
 ---
 
 ## SOT
 - Title: Add LSP inline ignore code action
-- Status: Draft
-- PR: TBD
+- Status: Ready
+- PR: #141
 
 ## What
 - [x] Add LSP `Add inline ignore` code action for findings that advertise `ignore`.

--- a/docs/pr/PR-TBD-lsp-inline-ignore-action.md
+++ b/docs/pr/PR-TBD-lsp-inline-ignore-action.md
@@ -1,0 +1,38 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: 2026-07-08
+branch: feat/lsp-inline-ignore-action
+commit: 8772577c8b9f1895aa3e6d13e8878df420200cd5
+title: Add LSP inline ignore code action
+---
+
+## SOT
+- Title: Add LSP inline ignore code action
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add LSP `Add inline ignore` code action for findings that advertise `ignore`.
+- [x] Resolve comment syntax from document language or file extension.
+- [x] Hide inline ignore for JSON and other commentless formats.
+- [x] Reuse UTF-16 positions for insertion edits without using `masked_snippet` as a range source.
+
+## Verification
+- [x] `cargo test -p veil-lsp`
+- [x] `cargo fmt --all`
+- [x] `cargo test --workspace --lib --bins`
+- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [x] `git diff --check`
+
+## Non-goals
+- [x] Do not implement partial mask.
+- [x] Do not change diagnostic payload shape.
+- [x] Do not add inline ignore for JSON/commentless formats.
+
+## Evidence
+- `veil-lsp` tests passed with new inline ignore coverage for Rust and JSON/commentless suppression.
+- Workspace lib/bin tests passed across `veil-cli`, `veil-config`, `veil-core`, `veil-guardian`, `veil-lsp`, `veil-pro`, and `veil-server`.
+- Workspace clippy passed with `-D warnings`.


### PR DESCRIPTION
## Summary
- add an `Add inline ignore` LSP code action for findings that advertise `ignore`
- resolve comment syntax from document language or file extension and suppress the action for JSON/commentless formats
- keep UTF-16 positions as the edit source while avoiding `maskedSnippet` for range reconstruction

## SOT
- `docs/pr/PR-141-lsp-inline-ignore-action.md`

## Verification
- `cargo test -p veil-lsp`
- `cargo fmt --all`
- `cargo test --workspace --lib --bins`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

## Non-goals
- no partial mask
- no diagnostic payload changes
- no inline ignore for JSON/commentless formats
