### PR TITLE
Align partial mask with last-four design

### DIFF
--- a/crates/veil-core/src/masking/mod.rs
+++ b/crates/veil-core/src/masking/mod.rs
@@ -2,6 +2,16 @@ use veil_config::MaskMode;
 
 pub const DEFAULT_PLACEHOLDER: &str = "<REDACTED>";
 
+fn partial_mask(secret: &str) -> String {
+    let chars: Vec<char> = secret.chars().collect();
+    if chars.len() <= 4 {
+        return "****".to_string();
+    }
+
+    let suffix: String = chars[chars.len().saturating_sub(4)..].iter().collect();
+    format!("****{suffix}")
+}
+
 pub fn apply_masks(
     content: &str,
     ranges: Vec<std::ops::Range<usize>>,
@@ -43,18 +53,7 @@ pub fn apply_masks(
         let secret = &content[range.clone()];
         let replacement = match mode {
             MaskMode::Redact => placeholder.to_string(),
-            MaskMode::Partial => {
-                // TODO: partial masking currently assumes byte offsets which works for ASCII secrets.
-                // For multibyte secrets, this might split characters.
-                let char_count = secret.chars().count();
-                if char_count <= 4 {
-                    "****".to_string()
-                } else {
-                    let start: String = secret.chars().take(4).collect();
-                    let end: String = secret.chars().skip(char_count.saturating_sub(4)).collect();
-                    format!("{}...{}", start, end)
-                }
-            }
+            MaskMode::Partial => partial_mask(secret),
             MaskMode::Plain => secret.to_string(), // Unreachable due to early exit
         };
 
@@ -146,19 +145,7 @@ pub fn apply_masks_spans(content: &str, mut spans: Vec<MaskSpan>, mode: MaskMode
         let secret_chunk = &content[range.clone()];
         let replacement = match mode {
             MaskMode::Redact => ph,
-            MaskMode::Partial => {
-                let char_count = secret_chunk.chars().count();
-                if char_count <= 4 {
-                    "****".to_string()
-                } else {
-                    let start: String = secret_chunk.chars().take(4).collect();
-                    let end: String = secret_chunk
-                        .chars()
-                        .skip(char_count.saturating_sub(4))
-                        .collect();
-                    format!("{}...{}", start, end)
-                }
-            }
+            MaskMode::Partial => partial_mask(secret_chunk),
             MaskMode::Plain => secret_chunk.to_string(),
         };
 
@@ -200,7 +187,7 @@ mod tests {
         let ranges = vec![0..18];
         assert_eq!(
             apply_masks(text, ranges, MaskMode::Partial, DEFAULT_PLACEHOLDER),
-            "AKIA...ABCD"
+            "****ABCD"
         );
     }
 
@@ -212,6 +199,16 @@ mod tests {
         assert_eq!(
             apply_masks(text, ranges, MaskMode::Partial, DEFAULT_PLACEHOLDER),
             "PWD=****"
+        );
+    }
+
+    #[test]
+    fn test_mask_partial_is_unicode_safe() {
+        let text = "秘密１２３４５６";
+        let ranges = vec![0..text.len()];
+        assert_eq!(
+            apply_masks(text, ranges, MaskMode::Partial, DEFAULT_PLACEHOLDER),
+            "****３４５６"
         );
     }
 
@@ -395,5 +392,33 @@ mod tests {
 
         let result = apply_masks_spans(text, spans, MaskMode::Redact);
         assert_eq!(result, "<OBS>2345"); // 0..12 replaced by <OBS>. Remainder "2345" (index 12..)
+    }
+
+    #[test]
+    fn test_mask_spans_partial_uses_last_four_chars_only() {
+        let text = "AKIA1234567890ABCD";
+        let spans = vec![MaskSpan {
+            start: 0,
+            end: text.len(),
+            placeholder: "<SECRET>".to_string(),
+            priority: 300,
+        }];
+
+        let result = apply_masks_spans(text, spans, MaskMode::Partial);
+        assert_eq!(result, "****ABCD");
+    }
+
+    #[test]
+    fn test_mask_spans_partial_is_unicode_safe() {
+        let text = "秘密１２３４５６";
+        let spans = vec![MaskSpan {
+            start: 0,
+            end: text.len(),
+            placeholder: "<SECRET>".to_string(),
+            priority: 300,
+        }];
+
+        let result = apply_masks_spans(text, spans, MaskMode::Partial);
+        assert_eq!(result, "****３４５６");
     }
 }

--- a/docs/pr/PR-142-core-partial-mask-unicode.md
+++ b/docs/pr/PR-142-core-partial-mask-unicode.md
@@ -1,18 +1,18 @@
 ---
 release: TBD
 epic: A
-pr: TBD
-status: Draft
+pr: 142
+status: Ready
 created_at: 2026-07-08
 branch: feat/core-partial-mask-unicode
-commit: 78217704a88006b706ec6c1de97a9ef1adce77eb
+commit: 61581caec0fad6abac006509e70276019d102921
 title: Align partial mask with last-four design
 ---
 
 ## SOT
 - Title: Align partial mask with last-four design
-- Status: Draft
-- PR: TBD
+- Status: Ready
+- PR: #142
 
 ## What
 - [x] Align `MaskMode::Partial` with the design contract to retain only the last four characters.

--- a/docs/pr/PR-TBD-core-partial-mask-unicode.md
+++ b/docs/pr/PR-TBD-core-partial-mask-unicode.md
@@ -1,0 +1,37 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Draft
+created_at: 2026-07-08
+branch: feat/core-partial-mask-unicode
+commit: 78217704a88006b706ec6c1de97a9ef1adce77eb
+title: Align partial mask with last-four design
+---
+
+## SOT
+- Title: Align partial mask with last-four design
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Align `MaskMode::Partial` with the design contract to retain only the last four characters.
+- [x] Share the partial mask formatting logic between range-based and span-based masking.
+- [x] Add multibyte tests so partial masking is safe for Unicode text.
+
+## Verification
+- [x] `cargo test -p veil-core masking::tests`
+- [x] `cargo fmt --all`
+- [x] `cargo test --workspace --lib --bins`
+- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [x] `git diff --check`
+
+## Non-goals
+- [x] Do not wire new LSP code actions.
+- [x] Do not change redact or plain mask behavior.
+- [x] Do not change diagnostic payloads.
+
+## Evidence
+- `veil-core` masking tests passed with new Unicode-safe partial mask coverage for both range-based and span-based masking.
+- Workspace lib/bin tests passed across `veil-cli`, `veil-config`, `veil-core`, `veil-guardian`, `veil-lsp`, `veil-pro`, and `veil-server`.
+- Workspace clippy passed with `-D warnings`.


### PR DESCRIPTION
## Summary
- align `MaskMode::Partial` with the design contract so masking keeps only the last four characters
- share the partial masking formatter between range-based and span-based masking paths
- add multibyte coverage so partial masking is safe for Unicode text

## SOT
- `docs/pr/PR-142-core-partial-mask-unicode.md`

## Verification
- `cargo test -p veil-core masking::tests`
- `cargo fmt --all`
- `cargo test --workspace --lib --bins`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

## Non-goals
- no new LSP code actions
- no redact/plain behavior changes
- no diagnostic payload changes
