### PR TITLE
Add LSP partial mask code action

### DIFF
--- a/crates/veil-lsp/src/code_actions.rs
+++ b/crates/veil-lsp/src/code_actions.rs
@@ -5,7 +5,8 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Diagnostic, NumberOrString, Position,
     TextEdit, Url, WorkspaceEdit,
 };
-use veil_core::DEFAULT_PLACEHOLDER;
+use veil_config::MaskMode;
+use veil_core::{apply_masks, DEFAULT_PLACEHOLDER};
 
 use crate::document_store::{byte_range_for_lsp_range, line_byte_bounds};
 
@@ -20,6 +21,7 @@ pub fn code_actions(
         .flat_map(|diagnostic| {
             [
                 mask_code_action(uri, text, diagnostic),
+                partial_mask_code_action(uri, text, diagnostic),
                 inline_ignore_code_action(uri, language_id, text, diagnostic),
             ]
         })
@@ -49,6 +51,43 @@ fn mask_code_action(uri: &Url, text: &str, diagnostic: &Diagnostic) -> Option<Co
         )),
         command: None,
         is_preferred: Some(true),
+        disabled: None,
+        data: None,
+    })
+}
+
+fn partial_mask_code_action(uri: &Url, text: &str, diagnostic: &Diagnostic) -> Option<CodeAction> {
+    if !supports_action(diagnostic, "partial_mask") {
+        return None;
+    }
+
+    let byte_range = byte_range_for_lsp_range(text, diagnostic.range)?;
+    if byte_range.is_empty() {
+        return None;
+    }
+
+    let selected_text = text.get(byte_range)?;
+    if selected_text == DEFAULT_PLACEHOLDER {
+        return None;
+    }
+
+    let replacement = apply_masks(
+        selected_text,
+        std::iter::once(0..selected_text.len()).collect(),
+        MaskMode::Partial,
+        DEFAULT_PLACEHOLDER,
+    );
+    if replacement == selected_text {
+        return None;
+    }
+
+    Some(CodeAction {
+        title: "Partial mask".to_string(),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(workspace_edit(uri, diagnostic.range, replacement)),
+        command: None,
+        is_preferred: Some(false),
         disabled: None,
         data: None,
     })
@@ -227,13 +266,13 @@ mod tests {
                 "score": 92,
                 "grade": "CRITICAL",
                 "maskedSnippet": "token = <REDACTED>",
-                "actions": ["mask", "ignore"],
+                "actions": ["mask", "partial_mask", "ignore"],
             })),
         }
     }
 
     #[test]
-    fn code_actions_return_mask_and_inline_ignore_for_rust() {
+    fn code_actions_return_mask_partial_and_inline_ignore_for_rust() {
         let uri = Url::parse("file:///tmp/example.rs").expect("uri");
         let diagnostics = code_actions(
             &uri,
@@ -242,7 +281,7 @@ mod tests {
             &[finding_diagnostic()],
         );
 
-        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics.len(), 3);
 
         let CodeActionOrCommand::CodeAction(mask_action) = &diagnostics[0] else {
             panic!("expected code action");
@@ -254,7 +293,17 @@ mod tests {
         assert_eq!(mask_text_edits[0].range, finding_diagnostic().range);
         assert_eq!(mask_text_edits[0].new_text, DEFAULT_PLACEHOLDER);
 
-        let CodeActionOrCommand::CodeAction(ignore_action) = &diagnostics[1] else {
+        let CodeActionOrCommand::CodeAction(partial_mask_action) = &diagnostics[1] else {
+            panic!("expected code action");
+        };
+        assert_eq!(partial_mask_action.title, "Partial mask");
+        let partial_mask_edit = partial_mask_action.edit.as_ref().expect("workspace edit");
+        let partial_mask_changes = partial_mask_edit.changes.as_ref().expect("text edits");
+        let partial_mask_text_edits = partial_mask_changes.get(&uri).expect("uri edits");
+        assert_eq!(partial_mask_text_edits[0].range, finding_diagnostic().range);
+        assert_eq!(partial_mask_text_edits[0].new_text, "****alue");
+
+        let CodeActionOrCommand::CodeAction(ignore_action) = &diagnostics[2] else {
             panic!("expected code action");
         };
         assert_eq!(ignore_action.title, "Add inline ignore");
@@ -287,11 +336,15 @@ mod tests {
             &[finding_diagnostic()],
         );
 
-        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics.len(), 2);
         let CodeActionOrCommand::CodeAction(action) = &diagnostics[0] else {
             panic!("expected code action");
         };
         assert_eq!(action.title, "Mask value");
+        let CodeActionOrCommand::CodeAction(action) = &diagnostics[1] else {
+            panic!("expected code action");
+        };
+        assert_eq!(action.title, "Partial mask");
     }
 
     #[test]
@@ -304,11 +357,15 @@ mod tests {
             &[finding_diagnostic()],
         );
 
-        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics.len(), 2);
         let CodeActionOrCommand::CodeAction(action) = &diagnostics[0] else {
             panic!("expected code action");
         };
         assert_eq!(action.title, "Mask value");
+        let CodeActionOrCommand::CodeAction(action) = &diagnostics[1] else {
+            panic!("expected code action");
+        };
+        assert_eq!(action.title, "Partial mask");
     }
 
     #[test]
@@ -342,5 +399,48 @@ mod tests {
             panic!("expected code action");
         };
         assert_eq!(action.title, "Add inline ignore");
+    }
+
+    #[test]
+    fn code_actions_partial_mask_is_unicode_safe() {
+        let uri = Url::parse("file:///tmp/example.txt").expect("uri");
+        let diagnostic = Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 8,
+                },
+                end: Position {
+                    line: 0,
+                    character: 16,
+                },
+            },
+            severity: None,
+            code: Some(NumberOrString::String("secret.test".to_string())),
+            code_description: None,
+            source: Some("veil".to_string()),
+            message: "Sensitive data detected".to_string(),
+            related_information: None,
+            tags: None,
+            data: Some(json!({
+                "ruleId": "secret.test",
+                "score": 92,
+                "grade": "CRITICAL",
+                "maskedSnippet": "token = <REDACTED>",
+                "actions": ["partial_mask"],
+            })),
+        };
+
+        let diagnostics = code_actions(&uri, "text", "token = 秘密１２３４５６", &[diagnostic]);
+
+        assert_eq!(diagnostics.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &diagnostics[0] else {
+            panic!("expected code action");
+        };
+        assert_eq!(action.title, "Partial mask");
+        let edit = action.edit.as_ref().expect("workspace edit");
+        let changes = edit.changes.as_ref().expect("text edits");
+        let text_edits = changes.get(&uri).expect("uri edits");
+        assert_eq!(text_edits[0].new_text, "****３４５６");
     }
 }

--- a/crates/veil-lsp/src/diagnostics.rs
+++ b/crates/veil-lsp/src/diagnostics.rs
@@ -28,7 +28,7 @@ pub fn finding_to_diagnostic(finding: &Finding) -> Diagnostic {
             "score": finding.score,
             "grade": finding.grade.to_string(),
             "maskedSnippet": finding.masked_snippet,
-            "actions": ["mask", "ignore"],
+            "actions": ["mask", "partial_mask", "ignore"],
         })),
     }
 }
@@ -182,7 +182,18 @@ mod tests {
             data.get("actions")
                 .and_then(|value| value.as_array())
                 .map(Vec::len),
-            Some(2)
+            Some(3)
+        );
+        assert_eq!(
+            data.get("actions")
+                .and_then(|value| value.as_array())
+                .map(|actions| {
+                    actions
+                        .iter()
+                        .filter_map(|value| value.as_str())
+                        .collect::<Vec<_>>()
+                }),
+            Some(vec!["mask", "partial_mask", "ignore"])
         );
         assert!(!data_text.contains("raw-secret-value"));
         assert!(!data_text.contains("token = raw-secret-value"));

--- a/docs/design/enterprise_jp_pii/06_lsp_design.md
+++ b/docs/design/enterprise_jp_pii/06_lsp_design.md
@@ -134,7 +134,7 @@ pub struct LspFinding {
 | SQL | `--` | `-- veil:ignore=...` |
 | JSON | なし | inline ignore actionを出さない |
 
-現在の実装は staged rollout とし、`Mask value` と `Add inline ignore` の quick fix を配線する。`Partial mask` は follow-up とする。
+現在の実装は `Mask value` / `Partial mask` / `Add inline ignore` の quick fix を配線する。
 
 ### 安全ルール
 - CodeActionは自動適用しない。

--- a/docs/pr/PR-TBD-lsp-partial-mask-code-action.md
+++ b/docs/pr/PR-TBD-lsp-partial-mask-code-action.md
@@ -1,0 +1,39 @@
+---
+release: TBD
+epic: A
+pr: TBD
+status: Ready
+created_at: 2026-07-09
+branch: feat/lsp-partial-mask-code-action
+commit: TBD
+title: Add LSP partial mask code action
+---
+
+## SOT
+- Title: Add LSP partial mask code action
+- Status: Ready
+- PR: TBD
+
+## What
+- [x] Add `partial_mask` to the LSP diagnostic action metadata.
+- [x] Expose a `Partial mask` quick fix alongside `Mask value` when the diagnostic supports it.
+- [x] Apply the existing core `MaskMode::Partial` masking logic to the diagnostic range instead of inventing a separate LSP masking path.
+- [x] Keep inline ignore unavailable for JSON while still offering full and partial masking.
+- [x] Update the LSP design note so the documented quick fixes match the implementation.
+
+## Verification
+- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` - PASS
+- [x] `git diff --check` - PASS
+- [x] `cargo test -p veil-lsp --all-targets` - PASS (`23` tests)
+
+## Evidence
+- Local command output observed on 2026-07-09 in `feat/lsp-partial-mask-code-action`.
+- CI evidence will be the GitHub pull request checks for this branch.
+
+## Non-goals
+- [x] Does not change scanner finding ranges; CodeAction continues to trust the diagnostic range as the SOT.
+- [x] Does not add partial masking to languages or contexts where no diagnostic action advertises it.
+- [x] Does not change core partial masking semantics.
+
+## Rollback
+- Revert this PR as a unit, or remove the generated SOT file if the PR is abandoned.


### PR DESCRIPTION
## Summary
- Add `partial_mask` to LSP diagnostic action metadata.
- Add a `Partial mask` quick fix that uses the existing core partial masking logic for the diagnostic range.
- Update LSP quick-fix tests, including a Unicode-safe partial-mask case, and align the design note.

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` - PASS
- `git diff --check` - PASS
- `cargo test -p veil-lsp --all-targets` - PASS

## SOT
- docs/pr/PR-TBD-lsp-partial-mask-code-action.md