### PR TITLE
Add CLI entrypoint for LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4587,6 +4587,7 @@ dependencies = [
 name = "veil-lsp"
 version = "0.17.0"
 dependencies = [
+ "anyhow",
  "serde_json",
  "tokio",
  "tower-lsp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,6 +4508,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "tokio",
  "toml 0.8.23",
  "toml_edit 0.22.27",
  "tracing",
@@ -4516,6 +4517,7 @@ dependencies = [
  "veil-config",
  "veil-core",
  "veil-guardian",
+ "veil-lsp",
  "zip",
 ]
 

--- a/crates/veil-cli/Cargo.toml
+++ b/crates/veil-cli/Cargo.toml
@@ -19,6 +19,7 @@ jp_mynumber_checksum = ["veil-core/jp_mynumber_checksum"]
 veil-core = { path = "../veil-core" }
 veil-config = { path = "../veil-config" }
 veil-guardian = { path = "../veil-guardian" }
+veil-lsp = { path = "../veil-lsp" }
 clap = { version = "4.5", features = ["derive", "env", "cargo"] }
 colored = "2.1"
 anyhow = "1.0"
@@ -26,6 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { version = "1.0", features = ["rt", "rt-multi-thread"] }
 git2 = "0.20.4"
 chrono = "0.4"
 indicatif = "0.17"

--- a/crates/veil-cli/Cargo.toml
+++ b/crates/veil-cli/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tokio = { version = "1.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["rt"] }
 git2 = "0.20.4"
 chrono = "0.4"
 indicatif = "0.17"

--- a/crates/veil-cli/src/cli.rs
+++ b/crates/veil-cli/src/cli.rs
@@ -149,6 +149,12 @@ pub enum Commands {
     /// Rules related commands
     #[command(subcommand)]
     Rules(RulesCommand),
+    /// Run the Veil language server over stdio
+    Lsp {
+        /// Apply a built-in preset as the base config layer
+        #[arg(long, value_name = "ID")]
+        preset: Option<String>,
+    },
     /// Scan dependencies for vulnerabilities
     Guardian(GuardianArgs),
     /// SOT (Source of Truth) tools

--- a/crates/veil-cli/src/commands/lsp.rs
+++ b/crates/veil-cli/src/commands/lsp.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 
-pub fn run(config_path: Option<&PathBuf>, preset_id: Option<&str>) -> Result<()> {
+pub fn run(config_path: Option<&PathBuf>, preset_id: Option<&str>, quiet: bool) -> Result<()> {
     let config = crate::config_loader::load_effective_config_with_preset(config_path, preset_id)?;
 
-    if let Some(preset_id) = preset_id {
+    if let Some(preset_id) = preset_id.filter(|_| !quiet) {
         eprintln!(
             "Using preset '{}' as the base config layer; user/org/repo config may override it.",
             preset_id
@@ -15,6 +15,6 @@ pub fn run(config_path: Option<&PathBuf>, preset_id: Option<&str>) -> Result<()>
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    runtime.block_on(veil_lsp::server::run_stdio_with_config(config));
+    runtime.block_on(veil_lsp::server::run_stdio_with_config(config))?;
     Ok(())
 }

--- a/crates/veil-cli/src/commands/lsp.rs
+++ b/crates/veil-cli/src/commands/lsp.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+pub fn run(config_path: Option<&PathBuf>, preset_id: Option<&str>) -> Result<()> {
+    let config = crate::config_loader::load_effective_config_with_preset(config_path, preset_id)?;
+
+    if let Some(preset_id) = preset_id {
+        eprintln!(
+            "Using preset '{}' as the base config layer; user/org/repo config may override it.",
+            preset_id
+        );
+    }
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(veil_lsp::server::run_stdio_with_config(config));
+    Ok(())
+}

--- a/crates/veil-cli/src/commands/mod.rs
+++ b/crates/veil-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod guardian;
 pub mod ignore;
 pub mod init;
 pub mod interactive_scan;
+pub mod lsp;
 pub mod mask;
 pub mod pre_commit;
 pub mod rules;

--- a/crates/veil-cli/src/main.rs
+++ b/crates/veil-cli/src/main.rs
@@ -140,6 +140,9 @@ fn main() -> anyhow::Result<()> {
                 commands::rules::promote_templates(args).map(|_| false)
             }
         },
+        Some(Commands::Lsp { preset }) => {
+            commands::lsp::run(cli.config.as_ref(), preset.as_deref()).map(|_| false)
+        }
         Some(Commands::Guardian(args)) => commands::guardian::run(args.clone()).map(|_| false),
         Some(Commands::Sot(cmd)) => commands::sot::run(cmd).map(|_| false),
         Some(Commands::Exceptions(args)) => commands::exceptions::run(args).map(|_| false),

--- a/crates/veil-cli/src/main.rs
+++ b/crates/veil-cli/src/main.rs
@@ -141,7 +141,7 @@ fn main() -> anyhow::Result<()> {
             }
         },
         Some(Commands::Lsp { preset }) => {
-            commands::lsp::run(cli.config.as_ref(), preset.as_deref()).map(|_| false)
+            commands::lsp::run(cli.config.as_ref(), preset.as_deref(), cli.quiet).map(|_| false)
         }
         Some(Commands::Guardian(args)) => commands::guardian::run(args.clone()).map(|_| false),
         Some(Commands::Sot(cmd)) => commands::sot::run(cmd).map(|_| false),

--- a/crates/veil-cli/tests/cmd/help.toml
+++ b/crates/veil-cli/tests/cmd/help.toml
@@ -8,6 +8,7 @@ A high-performance secret detection tool
 Commands:
   scan           Scan files for secrets
 ...
+  lsp            Run the Veil language server over stdio
   guardian       Scan dependencies for vulnerabilities
 ...
   update         Check for updates (stub)

--- a/crates/veil-cli/tests/cmd/lsp-help.toml
+++ b/crates/veil-cli/tests/cmd/lsp-help.toml
@@ -1,0 +1,16 @@
+bin.name = "veil"
+args = ["lsp", "--help"]
+status = "success"
+stdout = """
+Run the Veil language server over stdio
+
+Usage: veil lsp [OPTIONS]
+
+Options:
+  -c, --config <CONFIG>  Path to config file (default: ./veil.toml)
+      --preset <ID>      Apply a built-in preset as the base config layer
+      --no-color         Disable colored output
+  -q, --quiet            Suppress non-essential output
+  -h, --help             Print help
+"""
+stderr = ""

--- a/crates/veil-lsp/Cargo.toml
+++ b/crates/veil-lsp/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 veil-core = { workspace = true }
 veil-config = { workspace = true }
+anyhow = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 tower-lsp = "0.20"

--- a/crates/veil-lsp/src/main.rs
+++ b/crates/veil-lsp/src/main.rs
@@ -1,4 +1,4 @@
 #[tokio::main]
-async fn main() {
-    veil_lsp::server::run_stdio().await;
+async fn main() -> anyhow::Result<()> {
+    veil_lsp::server::run_stdio().await
 }

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -197,7 +197,7 @@ pub async fn run_stdio() -> Result<()> {
 }
 
 pub async fn run_stdio_with_config(config: Config) -> Result<()> {
-    let remote_rules = remote_rules_for_config(&config);
+    let remote_rules = remote_rules_for_config(&config).await?;
     let rules = Arc::new(try_get_all_rules(&config, remote_rules)?);
     let config = Arc::new(config);
     let stdin = tokio::io::stdin();
@@ -252,16 +252,21 @@ fn is_ignored_by_config(path: &Path, config: &Config) -> bool {
         .any(|pattern| path_str.contains(pattern))
 }
 
-fn remote_rules_for_config(config: &Config) -> Vec<Rule> {
+async fn remote_rules_for_config(config: &Config) -> Result<Vec<Rule>> {
     let remote_url = std::env::var("VEIL_REMOTE_RULES_URL")
         .ok()
         .or_else(|| config.core.remote_rules_url.clone());
 
     let Some(url) = remote_url else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
-    match veil_core::remote::fetch_remote_rules(&url, 3) {
+    let fetch_url = url.clone();
+    let rules = match tokio::task::spawn_blocking(move || {
+        veil_core::remote::fetch_remote_rules(&fetch_url, 3)
+    })
+    .await?
+    {
         Ok(rules) => rules,
         Err(error) => {
             eprintln!(
@@ -270,7 +275,9 @@ fn remote_rules_for_config(config: &Config) -> Vec<Rule> {
             );
             Vec::new()
         }
-    }
+    };
+
+    Ok(rules)
 }
 
 fn path_for_uri(uri: &Url) -> PathBuf {

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -61,12 +61,25 @@ impl Backend {
                 return;
             };
 
-            let diagnostics = diagnostics_for_text(
-                &document.text,
-                &path_for_uri(&document.uri),
-                &rules,
-                &config,
-            );
+            let document_text = document.text.clone();
+            let document_path = path_for_uri(&document.uri);
+            let diagnostics = match tokio::task::spawn_blocking(move || {
+                diagnostics_for_text(&document_text, &document_path, &rules, &config)
+            })
+            .await
+            {
+                Ok(diagnostics) => diagnostics,
+                Err(error) => {
+                    client
+                        .log_message(
+                            MessageType::ERROR,
+                            format!("failed to run diagnostics scan: {error}"),
+                        )
+                        .await;
+                    clear_pending_scan_if_current(&pending_scans, &task_uri, scan_revision).await;
+                    return;
+                }
+            };
 
             if current_document_for_revision(&documents, &task_uri, scan_revision)
                 .await

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -8,7 +8,8 @@ use std::time::Duration;
 use crate::code_actions::code_actions;
 use crate::diagnostics::{findings_to_diagnostics, max_file_size_diagnostic};
 use crate::document_store::{DocumentState, DocumentStore};
-use tower_lsp::jsonrpc::Result;
+use anyhow::Result;
+use tower_lsp::jsonrpc::Result as LspResult;
 use tower_lsp::lsp_types::{
     CodeActionParams, CodeActionProviderCapability, CodeActionResponse, Diagnostic,
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
@@ -30,16 +31,13 @@ pub struct Backend {
 }
 
 impl Backend {
-    fn with_config(client: Client, config: Config) -> Self {
-        let rules = try_get_all_rules(&config, Vec::new())
-            .unwrap_or_else(|_| veil_core::get_default_rules());
-
+    fn with_config_and_rules(client: Client, config: Arc<Config>, rules: Arc<Vec<Rule>>) -> Self {
         Self {
             client,
             documents: Arc::new(tokio::sync::Mutex::new(DocumentStore::default())),
             pending_scans: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            config: Arc::new(config),
-            rules: Arc::new(rules),
+            config,
+            rules,
         }
     }
 
@@ -95,7 +93,7 @@ impl Backend {
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+    async fn initialize(&self, _: InitializeParams) -> LspResult<InitializeResult> {
         Ok(InitializeResult {
             capabilities: server_capabilities(),
             server_info: Some(ServerInfo {
@@ -166,7 +164,7 @@ impl LanguageServer for Backend {
         self.client.publish_diagnostics(uri, Vec::new(), None).await;
     }
 
-    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+    async fn code_action(&self, params: CodeActionParams) -> LspResult<Option<CodeActionResponse>> {
         let uri = params.text_document.uri;
         let document = {
             let documents = self.documents.lock().await;
@@ -189,22 +187,27 @@ impl LanguageServer for Backend {
         Ok(Some(actions))
     }
 
-    async fn shutdown(&self) -> Result<()> {
+    async fn shutdown(&self) -> LspResult<()> {
         Ok(())
     }
 }
 
-pub async fn run_stdio() {
-    run_stdio_with_config(Config::default()).await;
+pub async fn run_stdio() -> Result<()> {
+    run_stdio_with_config(Config::default()).await
 }
 
-pub async fn run_stdio_with_config(config: Config) {
+pub async fn run_stdio_with_config(config: Config) -> Result<()> {
+    let rules = Arc::new(try_get_all_rules(&config, Vec::new())?);
+    let config = Arc::new(config);
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
-    let (service, socket) =
-        LspService::build(|client| Backend::with_config(client, config.clone())).finish();
+    let (service, socket) = LspService::build(|client| {
+        Backend::with_config_and_rules(client, Arc::clone(&config), Arc::clone(&rules))
+    })
+    .finish();
 
     Server::new(stdin, stdout, socket).serve(service).await;
+    Ok(())
 }
 
 pub fn server_capabilities() -> ServerCapabilities {
@@ -223,6 +226,10 @@ pub fn diagnostics_for_text(
     rules: &[Rule],
     config: &Config,
 ) -> Vec<Diagnostic> {
+    if is_ignored_by_config(path, config) {
+        return Vec::new();
+    }
+
     let max_size_bytes = config
         .core
         .max_file_size
@@ -233,6 +240,15 @@ pub fn diagnostics_for_text(
     }
 
     findings_to_diagnostics(&scan_content(text, path, rules, config))
+}
+
+fn is_ignored_by_config(path: &Path, config: &Config) -> bool {
+    let path_str = path.to_string_lossy();
+    config
+        .core
+        .ignore
+        .iter()
+        .any(|pattern| path_str.contains(pattern))
 }
 
 fn path_for_uri(uri: &Url) -> PathBuf {
@@ -303,10 +319,12 @@ fn document_for_revision(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use tower_lsp::lsp_types::{
         CodeActionProviderCapability, DiagnosticSeverity, NumberOrString,
         TextDocumentSyncCapability,
     };
+    use veil_config::RuleConfig;
 
     #[test]
     fn server_name_matches_binary_name() {
@@ -389,6 +407,51 @@ mod tests {
         let data_text = data.to_string();
         assert!(!data_text.contains("test@example.com"));
         assert!(!data_text.contains("contact test@example.com"));
+    }
+
+    #[test]
+    fn diagnostics_for_text_honors_config_ignores() {
+        let mut config = Config::default();
+        config.core.ignore.push("generated".to_string());
+        let rules = try_get_all_rules(&config, Vec::new()).expect("rules");
+
+        let diagnostics = diagnostics_for_text(
+            "contact test@example.com\n",
+            Path::new("src/generated/secrets.txt"),
+            &rules,
+            &config,
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_stdio_with_config_rejects_rule_loading_errors() {
+        let mut config = Config::default();
+        config.rules = HashMap::from([(
+            "custom.invalid_validator".to_string(),
+            RuleConfig {
+                enabled: true,
+                enabled_is_set: true,
+                severity: None,
+                pattern: Some("SECRET".to_string()),
+                score: None,
+                category: None,
+                tags: None,
+                base_score: None,
+                context_lines_before: None,
+                context_lines_after: None,
+                validator: Some("unknown_validator".to_string()),
+                description: None,
+                placeholder: None,
+            },
+        )]);
+
+        let error = run_stdio_with_config(config).await.unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Unknown validator 'unknown_validator'"));
     }
 
     #[test]

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -197,7 +197,8 @@ pub async fn run_stdio() -> Result<()> {
 }
 
 pub async fn run_stdio_with_config(config: Config) -> Result<()> {
-    let rules = Arc::new(try_get_all_rules(&config, Vec::new())?);
+    let remote_rules = remote_rules_for_config(&config);
+    let rules = Arc::new(try_get_all_rules(&config, remote_rules)?);
     let config = Arc::new(config);
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
@@ -249,6 +250,27 @@ fn is_ignored_by_config(path: &Path, config: &Config) -> bool {
         .ignore
         .iter()
         .any(|pattern| path_str.contains(pattern))
+}
+
+fn remote_rules_for_config(config: &Config) -> Vec<Rule> {
+    let remote_url = std::env::var("VEIL_REMOTE_RULES_URL")
+        .ok()
+        .or_else(|| config.core.remote_rules_url.clone());
+
+    let Some(url) = remote_url else {
+        return Vec::new();
+    };
+
+    match veil_core::remote::fetch_remote_rules(&url, 3) {
+        Ok(rules) => rules,
+        Err(error) => {
+            eprintln!(
+                "Warning: Failed to fetch remote rules from {}: {}. Continuing with local rules only.",
+                url, error
+            );
+            Vec::new()
+        }
+    }
 }
 
 fn path_for_uri(uri: &Url) -> PathBuf {

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -427,25 +427,27 @@ mod tests {
 
     #[tokio::test]
     async fn run_stdio_with_config_rejects_rule_loading_errors() {
-        let mut config = Config::default();
-        config.rules = HashMap::from([(
-            "custom.invalid_validator".to_string(),
-            RuleConfig {
-                enabled: true,
-                enabled_is_set: true,
-                severity: None,
-                pattern: Some("SECRET".to_string()),
-                score: None,
-                category: None,
-                tags: None,
-                base_score: None,
-                context_lines_before: None,
-                context_lines_after: None,
-                validator: Some("unknown_validator".to_string()),
-                description: None,
-                placeholder: None,
-            },
-        )]);
+        let config = Config {
+            rules: HashMap::from([(
+                "custom.invalid_validator".to_string(),
+                RuleConfig {
+                    enabled: true,
+                    enabled_is_set: true,
+                    severity: None,
+                    pattern: Some("SECRET".to_string()),
+                    score: None,
+                    category: None,
+                    tags: None,
+                    base_score: None,
+                    context_lines_before: None,
+                    context_lines_after: None,
+                    validator: Some("unknown_validator".to_string()),
+                    description: None,
+                    placeholder: None,
+                },
+            )]),
+            ..Config::default()
+        };
 
         let error = run_stdio_with_config(config).await.unwrap_err();
 

--- a/crates/veil-lsp/src/server.rs
+++ b/crates/veil-lsp/src/server.rs
@@ -30,8 +30,7 @@ pub struct Backend {
 }
 
 impl Backend {
-    fn new(client: Client) -> Self {
-        let config = Config::default();
+    fn with_config(client: Client, config: Config) -> Self {
         let rules = try_get_all_rules(&config, Vec::new())
             .unwrap_or_else(|_| veil_core::get_default_rules());
 
@@ -196,9 +195,14 @@ impl LanguageServer for Backend {
 }
 
 pub async fn run_stdio() {
+    run_stdio_with_config(Config::default()).await;
+}
+
+pub async fn run_stdio_with_config(config: Config) {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
-    let (service, socket) = LspService::new(Backend::new);
+    let (service, socket) =
+        LspService::build(|client| Backend::with_config(client, config.clone())).finish();
 
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/docs/pr/PR-145-lsp-cli-command.md
+++ b/docs/pr/PR-145-lsp-cli-command.md
@@ -1,7 +1,7 @@
 ---
 release: TBD
 epic: LSP
-pr: TBD
+pr: 145
 status: Draft
 created_at: 2026-07-11
 branch: feat/lsp-cli-command
@@ -14,7 +14,7 @@ title: Add CLI entrypoint for LSP
 ## SOT
 - Title: Add CLI entrypoint for LSP
 - Status: Draft
-- PR: TBD
+- PR: #145
 
 ## What
 - [x] Add `veil lsp` as a first-class CLI subcommand.

--- a/docs/pr/PR-TBD-lsp-cli-command.md
+++ b/docs/pr/PR-TBD-lsp-cli-command.md
@@ -1,0 +1,41 @@
+---
+release: TBD
+epic: LSP
+pr: TBD
+status: Draft
+created_at: 2026-07-11
+branch: feat/lsp-cli-command
+commit: 4ff7a60
+title: Add CLI entrypoint for LSP
+---
+
+# SOT: LSP CLI Entrypoint
+
+## SOT
+- Title: Add CLI entrypoint for LSP
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add `veil lsp` as a first-class CLI subcommand.
+- [x] Load the LSP server config through the existing CLI config loader.
+- [x] Support `--config` and `--preset` so CLI and editor diagnostics share the same effective config path.
+- [x] Keep the standalone `veil-lsp` binary behavior intact by preserving default-config stdio startup.
+
+## Verification
+- [x] `git diff --check` - pass
+- [x] `cargo check -p veil-cli` - pass
+- [x] `cargo test -p veil-cli cli_tests` - pass
+- [x] `cargo test -p veil-lsp` - pass
+
+## Evidence
+- Local verification completed after rebasing onto `origin/main`.
+- Commit under review: `4ff7a60`
+
+## Non-goals
+- [x] Do not add editor-specific workspace configuration discovery beyond the existing CLI config loader.
+- [x] Do not change diagnostic rules, code actions, masking behavior, or LSP protocol capabilities.
+- [x] Do not remove the standalone `veil-lsp` binary entrypoint.
+
+## Rollback
+- Revert this PR as a unit. The CLI `lsp` subcommand and injected-config server startup will be removed, while the previous standalone `veil-lsp` default startup path is restored.


### PR DESCRIPTION
## Summary
- Add `veil lsp` as a first-class CLI subcommand.
- Route LSP startup through the existing CLI config loader so `--config` and `--preset` resolve the same effective config used by CLI flows.
- Preserve standalone `veil-lsp` stdio startup with default config.

## SOT
- docs/pr/PR-145-lsp-cli-command.md

## Verification
- `git diff --check`
- `python3 scripts/check_docs_taxonomy.py`
- `cargo check -p veil-cli`
- `cargo test -p veil-cli cli_tests`
- `cargo test -p veil-lsp`

## Non-goals
- No LSP protocol capability changes.
- No diagnostic rule or code action behavior changes.