### PR TITLE
Sync LSP design implementation status

### DIFF
--- a/docs/design/enterprise_jp_pii/06_lsp_design.md
+++ b/docs/design/enterprise_jp_pii/06_lsp_design.md
@@ -166,11 +166,11 @@ vim.lsp.start({
 - [x] `didChange` のscanを debounce し、同一documentの古い結果をpublishしない。
 - [x] open document が最大サイズ超過のとき `MAX_FILE_SIZE` skipped diagnostic を publish する。
 - [x] UTF-8 byte offset → UTF-16 LSP range変換はCoreの`Finding.utf16_range`に集約し、LSP Diagnosticでは再計算しない。
-- [ ] `codeAction` for mask/ignore。
-- [ ] 言語別ignore comment registryを実装。
-- [ ] JSON等コメント不可ファイルではinline ignore actionを非表示。
-- [ ] fixtureでNeovim想定のdiagnosticテスト。
-- [ ] `veil lsp` をCLIに追加。
+- [x] `codeAction` for mask/partial mask/ignore。
+- [x] 言語別ignore comment registryを実装。
+- [x] JSON等コメント不可ファイルではinline ignore actionを非表示。
+- [x] fixtureでNeovim想定のdiagnosticテスト。
+- [x] `veil lsp` をCLIに追加。
 
 
 ## 6.11 v4 Range SOT

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -64,8 +64,8 @@ PR分割:
 - [x] `crates/veil-lsp` 作成
 - [x] tower-lsp integration
 - [x] diagnostics mapping
-- [ ] code actions
-- [ ] Neovim doc
+- [x] code actions
+- [x] Neovim doc
 
 ## Phase 5: Local Audit UI completion
 

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -1596,13 +1596,13 @@ vim.lsp.start({
 
 - [x] `crates/veil-lsp` workspace追加。
 - [x] `tower-lsp` server実装。
-- [ ] `scan_content` をLSPから呼び出す。
-- [ ] UTF-8 byte offset → UTF-16 LSP range変換を実装。
-- [ ] `codeAction` for mask/ignore。
-- [ ] 言語別ignore comment registryを実装。
-- [ ] JSON等コメント不可ファイルではinline ignore actionを非表示。
-- [ ] fixtureでNeovim想定のdiagnosticテスト。
-- [ ] `veil lsp` をCLIに追加。
+- [x] `scan_content` をLSPから呼び出す。
+- [x] UTF-8 byte offset → UTF-16 LSP range変換を実装。
+- [x] `codeAction` for mask/partial mask/ignore。
+- [x] 言語別ignore comment registryを実装。
+- [x] JSON等コメント不可ファイルではinline ignore actionを非表示。
+- [x] fixtureでNeovim想定のdiagnosticテスト。
+- [x] `veil lsp` をCLIに追加。
 
 
 ## 6.11 v4 Range SOT
@@ -2548,8 +2548,8 @@ PR分割:
 - [x] `crates/veil-lsp` 作成
 - [x] tower-lsp integration
 - [x] diagnostics mapping
-- [ ] code actions
-- [ ] Neovim doc
+- [x] code actions
+- [x] Neovim doc
 
 ## Phase 5: Local Audit UI completion
 

--- a/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
+++ b/docs/design/enterprise_jp_pii/implementation/task_breakdown.md
@@ -74,11 +74,11 @@
 - [x] score context modifierの単体テストを追加。
 - [x] JP PII fixtureが既存検知挙動を維持することを確認。
 
-## Later: LSP
+## LSP（実装済み）
 
-- [ ] `crates/veil-lsp` 追加
-- [ ] Diagnostics / CodeAction / ignore comments
-- [ ] JSONでinline ignore actionを出さないtest
+- [x] `crates/veil-lsp` 追加
+- [x] Diagnostics / CodeAction / ignore comments
+- [x] JSONでinline ignore actionを出さないtest
 
 
 ## Contract polish sync tasks

--- a/docs/pr/PR-146-lsp-design-status-sync.md
+++ b/docs/pr/PR-146-lsp-design-status-sync.md
@@ -1,11 +1,11 @@
 ---
 release: TBD
 epic: LSP
-pr: TBD
-status: Draft
+pr: 146
+status: Ready
 created_at: 2026-07-11
 branch: feat/lsp-design-status-sync
-commit: TBD
+commit: 0696022
 title: Sync LSP design implementation status
 ---
 
@@ -13,8 +13,8 @@ title: Sync LSP design implementation status
 
 ## SOT
 - Title: Sync LSP design implementation status
-- Status: Draft
-- PR: TBD
+- Status: Ready
+- PR: #146
 
 ## What
 - [x] Mark LSP code actions complete in the enterprise JP PII roadmap now that mask, partial mask, and inline ignore quick fixes are on `main`.

--- a/docs/pr/PR-TBD-lsp-design-status-sync.md
+++ b/docs/pr/PR-TBD-lsp-design-status-sync.md
@@ -1,0 +1,39 @@
+---
+release: TBD
+epic: LSP
+pr: TBD
+status: Draft
+created_at: 2026-07-11
+branch: feat/lsp-design-status-sync
+commit: TBD
+title: Sync LSP design implementation status
+---
+
+# SOT: Sync LSP Design Implementation Status
+
+## SOT
+- Title: Sync LSP design implementation status
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Mark LSP code actions complete in the enterprise JP PII roadmap now that mask, partial mask, and inline ignore quick fixes are on `main`.
+- [x] Mark the `veil lsp` CLI entrypoint and Neovim startup note complete after PR #145.
+- [x] Update the partial-mask SOT with its landed `main` commit instead of leaving the evidence as `TBD`.
+
+## Verification
+- [x] `python3 scripts/check_docs_taxonomy.py` - PASS
+- [x] `git diff --check` - PASS
+
+## Evidence
+- `crates/veil-lsp/src/code_actions.rs` contains `Mask value`, `Partial mask`, and `Add inline ignore` quick fixes.
+- `docs/design/enterprise_jp_pii/06_lsp_design.md` already documents the Neovim `vim.lsp.start` example for `veil lsp --preset fintech-jp`.
+- Partial mask landed on `main` as `16eb4f3 Add LSP partial mask code action`.
+
+## Non-goals
+- [x] Do not change LSP behavior.
+- [x] Do not publish or modify `.private/` design documents.
+- [x] Do not invent a PR number for commit-level evidence.
+
+## Rollback
+- Revert this docs-only PR to restore the previous implementation-status wording.

--- a/docs/pr/PR-TBD-lsp-partial-mask-code-action.md
+++ b/docs/pr/PR-TBD-lsp-partial-mask-code-action.md
@@ -5,7 +5,7 @@ pr: TBD
 status: Ready
 created_at: 2026-07-09
 branch: feat/lsp-partial-mask-code-action
-commit: TBD
+commit: 16eb4f3
 title: Add LSP partial mask code action
 ---
 
@@ -13,6 +13,7 @@ title: Add LSP partial mask code action
 - Title: Add LSP partial mask code action
 - Status: Ready
 - PR: TBD
+- Main commit: `16eb4f3`
 
 ## What
 - [x] Add `partial_mask` to the LSP diagnostic action metadata.
@@ -28,7 +29,8 @@ title: Add LSP partial mask code action
 
 ## Evidence
 - Local command output observed on 2026-07-09 in `feat/lsp-partial-mask-code-action`.
-- CI evidence will be the GitHub pull request checks for this branch.
+- The implementation is present on `main` as commit `16eb4f3 Add LSP partial mask code action`.
+- No separate GitHub PR number was assigned to this SOT at landing time; keep this file as the commit-level evidence record.
 
 ## Non-goals
 - [x] Does not change scanner finding ranges; CodeAction continues to trust the diagnostic range as the SOT.


### PR DESCRIPTION
## Summary
- Mark LSP code actions and the CLI LSP entrypoint complete in the enterprise JP PII design docs.
- Record the landed main commit for the partial-mask LSP SOT without inventing a PR number.
- Add a small SOT for this docs-only status sync.

## Verification
- python3 scripts/check_docs_taxonomy.py
- git diff --check HEAD~1..HEAD

## Notes
- This does not change LSP behavior.
- This does not publish or modify `.private/` design documents.