### PR TITLE
Add browser print path for audit reports

### DIFF
--- a/crates/veil-pro/frontend/src/app.css
+++ b/crates/veil-pro/frontend/src/app.css
@@ -173,3 +173,124 @@ p {
   background-color: rgba(134, 134, 139, 0.15);
   color: var(--text-secondary);
 }
+
+@media print {
+  :root {
+    --bg-primary: #ffffff;
+    --bg-secondary: #ffffff;
+    --text-primary: #111111;
+    --text-secondary: #4f4f54;
+    --glass-bg: #ffffff;
+    --glass-border: #d2d2d7;
+    --shadow-sm: none;
+    --shadow-md: none;
+    --shadow-lg: none;
+  }
+
+  body {
+    background: #ffffff;
+    color: #111111;
+  }
+
+  .dashboard-layout,
+  .content-area,
+  .scroll-content,
+  .scan-container,
+  .results-area {
+    display: block !important;
+    height: auto !important;
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: visible !important;
+  }
+
+  .sidebar,
+  .topbar,
+  .input-card,
+  .error-banner,
+  .results-toolbar .btn {
+    display: none !important;
+  }
+
+  .glass-panel {
+    background: #ffffff !important;
+    border: 1px solid #d2d2d7 !important;
+    border-radius: 8px !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
+
+  .results-toolbar {
+    display: block !important;
+    margin-bottom: 12px !important;
+  }
+
+  .results-toolbar h4 {
+    font-size: 18px !important;
+  }
+
+  .stats-cards {
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    gap: 8px !important;
+    margin-bottom: 12px !important;
+  }
+
+  .stat-card {
+    break-inside: avoid;
+    padding: 12px !important;
+  }
+
+  .stat-value {
+    font-size: 24px !important;
+  }
+
+  .stat-value.text-value {
+    font-size: 18px !important;
+  }
+
+  .findings-table {
+    break-inside: auto;
+  }
+
+  .table-wrapper {
+    overflow: visible !important;
+  }
+
+  table {
+    page-break-inside: auto;
+  }
+
+  tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  th,
+  td {
+    padding: 8px 10px !important;
+    font-size: 11px !important;
+    vertical-align: top;
+  }
+
+  .badge {
+    border: 1px solid currentColor;
+    background: transparent !important;
+    color: #111111 !important;
+    border-radius: 6px !important;
+    padding: 2px 6px !important;
+  }
+
+  .path-col,
+  .rule-col,
+  .context-col .code-block {
+    overflow-wrap: anywhere;
+    white-space: normal !important;
+  }
+
+  .code-block {
+    background: #ffffff !important;
+    border-color: #d2d2d7 !important;
+  }
+}

--- a/crates/veil-pro/frontend/src/lib/ScanView.svelte
+++ b/crates/veil-pro/frontend/src/lib/ScanView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FolderSearch, AlertTriangle, ShieldCheck, Play, Loader2, RotateCcw, Download } from 'lucide-svelte';
+  import { FolderSearch, AlertTriangle, ShieldCheck, Play, Loader2, RotateCcw, Download, Printer } from 'lucide-svelte';
   import type { ErrorEnvelope, PresetName, SafeFindingApiV1, ScanRequest, ScanResponse, SeverityName } from './api-contract';
   import type { ScanPreset, ScanState } from './ui-state';
   
@@ -196,6 +196,10 @@
       errorMsg = 'Network error downloading evidence.';
     }
   }
+
+  function printReport() {
+    window.print();
+  }
 </script>
 
 <div class="scan-container state-anim">
@@ -264,9 +268,14 @@
     <div class="results-area state-anim">
       <div class="results-toolbar">
         <h4>Scan Results</h4>
-        <button class="export-link btn btn-secondary btn-sm" onclick={() => downloadEvidence(scanStats!.runId)} type="button">
-          <Download size={14} /> Export Evidence Pack
-        </button>
+        <div class="results-actions">
+          <button class="export-link btn btn-secondary btn-sm" onclick={printReport} type="button" title="Print report">
+            <Printer size={14} /> Print Report
+          </button>
+          <button class="export-link btn btn-secondary btn-sm" onclick={() => downloadEvidence(scanStats!.runId)} type="button">
+            <Download size={14} /> Export Evidence Pack
+          </button>
+        </div>
       </div>
 
       <div class="stats-cards">
@@ -560,10 +569,21 @@
     flex: 0 0 auto;
   }
 
+  .results-actions {
+    display: inline-flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 10px;
+  }
+
   @media (max-width: 720px) {
     .results-toolbar {
       align-items: stretch;
       flex-direction: column;
+    }
+
+    .results-actions {
+      width: 100%;
     }
 
     .export-link {

--- a/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
+++ b/docs/design/enterprise_jp_pii/13_implementation_roadmap.md
@@ -73,15 +73,15 @@ PR分割:
 - [x] Svelte state machine
 - [x] Policy explain
 - [x] Evidence ZIP UX
-- [ ] PDF export path検討
+- [x] PDF export path検討（初期実装はbrowser print）
 
 ## Phase 6: PDF Report
 
 ### 方針
 HTMLをSOTにし、PDFは印刷最適CSSまたはローカルheadless rendererを別optional featureとする。
 
-- [ ] `report.print.html` CSS
-- [ ] `Export PDF` はbrowser printを初期案にする
+- [x] `report.print.html` CSS
+- [x] `Export PDF` はbrowser printを初期案にする
 - [ ] 将来: `--format pdf` はfeature gated
 
 ## Phase 7: Enterprise hardening

--- a/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
+++ b/docs/design/enterprise_jp_pii/DETAIL_DESIGN.md
@@ -2557,15 +2557,15 @@ PR分割:
 - [x] Svelte state machine
 - [x] Policy explain
 - [x] Evidence ZIP UX
-- [ ] PDF export path検討
+- [x] PDF export path検討（初期実装はbrowser print）
 
 ## Phase 6: PDF Report
 
 ### 方針
 HTMLをSOTにし、PDFは印刷最適CSSまたはローカルheadless rendererを別optional featureとする。
 
-- [ ] `report.print.html` CSS
-- [ ] `Export PDF` はbrowser printを初期案にする
+- [x] `report.print.html` CSS
+- [x] `Export PDF` はbrowser printを初期案にする
 - [ ] 将来: `--format pdf` はfeature gated
 
 ## Phase 7: Enterprise hardening

--- a/docs/pr/PR-147-ui-print-report-export.md
+++ b/docs/pr/PR-147-ui-print-report-export.md
@@ -1,11 +1,11 @@
 ---
 release: TBD
 epic: UI
-pr: TBD
-status: Draft
+pr: 147
+status: Ready
 created_at: 2026-07-11
 branch: feat/ui-print-report-export
-commit: TBD
+commit: 462e1b0
 title: Add browser print path for audit reports
 ---
 
@@ -13,8 +13,8 @@ title: Add browser print path for audit reports
 
 ## SOT
 - Title: Add browser print path for audit reports
-- Status: Draft
-- PR: TBD
+- Status: Ready
+- PR: #147
 
 ## What
 - [x] Add a `Print Report` action beside Evidence ZIP export in Local Audit UI scan results.

--- a/docs/pr/PR-TBD-ui-print-report-export.md
+++ b/docs/pr/PR-TBD-ui-print-report-export.md
@@ -1,0 +1,41 @@
+---
+release: TBD
+epic: UI
+pr: TBD
+status: Draft
+created_at: 2026-07-11
+branch: feat/ui-print-report-export
+commit: TBD
+title: Add browser print path for audit reports
+---
+
+# SOT: Add Browser Print Path For Audit Reports
+
+## SOT
+- Title: Add browser print path for audit reports
+- Status: Draft
+- PR: TBD
+
+## What
+- [x] Add a `Print Report` action beside Evidence ZIP export in Local Audit UI scan results.
+- [x] Use browser print as the initial PDF export path instead of adding a headless renderer or native PDF dependency.
+- [x] Add print CSS that hides navigation and scan controls while preserving scan summary and finding tables.
+- [x] Mark the PDF export path and browser print design tasks complete while keeping native `--format pdf` future-gated.
+
+## Verification
+- [x] `npm --prefix crates/veil-pro/frontend run check` - PASS
+- [x] `npm --prefix crates/veil-pro/frontend run build` - PASS
+- [x] `python3 scripts/check_docs_taxonomy.py` - PASS
+- [x] `git diff --check` - PASS
+
+## Evidence
+- The UI export path remains local-only and depends on `window.print()`.
+- The print stylesheet is CSS-only and does not add network, renderer, or file-system permissions.
+
+## Non-goals
+- [x] Do not add CLI `--format pdf`.
+- [x] Do not add a headless browser or server-side PDF renderer.
+- [x] Do not change Evidence ZIP generation.
+
+## Rollback
+- Revert this PR as a unit to remove the print button, print CSS, and roadmap status updates.


### PR DESCRIPTION
## Summary
- Add a Print Report action to Local Audit UI scan results.
- Add print CSS so browser print/PDF output keeps the scan summary and findings while hiding navigation and scan controls.
- Mark the browser-print PDF export path complete in the enterprise JP PII design docs while keeping native `--format pdf` future-gated.

## Verification
- npm --prefix crates/veil-pro/frontend run check
- npm --prefix crates/veil-pro/frontend run build
- python3 scripts/check_docs_taxonomy.py
- git diff --check

## Notes
- No headless renderer or native PDF dependency is added.
- Evidence ZIP generation is unchanged.